### PR TITLE
Fix: uint16_t is too small for our match data

### DIFF
--- a/include/nakama-c/NTypes.h
+++ b/include/nakama-c/NTypes.h
@@ -55,7 +55,7 @@ typedef uint64_t NTimestamp;
 typedef struct NBytes
 {
     uint8_t* bytes;
-    uint16_t size;
+    uint32_t size;
 } sNBytes;
 
 /// Constant for defaut port.

--- a/include/nakama-cpp-c-wrapper/Impl/NDataHelperWrapperImpl.h
+++ b/include/nakama-cpp-c-wrapper/Impl/NDataHelperWrapperImpl.h
@@ -130,7 +130,7 @@ NStringDoubleMap toCppNStringDoubleMap(::NStringDoubleMap map)
 void assign(sNBytes& cData, const NBytes& data)
 {
     cData.bytes = (uint8_t*)data.data();
-    cData.size = (uint16_t)data.size();
+    cData.size = (uint32_t)data.size();
 }
 
 void assign(NBytes& data, const sNBytes* cData)

--- a/src/nakama-c/DataHelperC.cpp
+++ b/src/nakama-c/DataHelperC.cpp
@@ -90,7 +90,7 @@ void assign(Nakama::NBytes& data, const sNBytes* cData)
     if (cData)
     {
         data.resize(cData->size);
-        for (uint16_t i=0; i < cData->size; ++i)
+        for (uint32_t i=0; i < cData->size; ++i)
         {
             data[i] = cData->bytes[i];
         }
@@ -100,7 +100,7 @@ void assign(Nakama::NBytes& data, const sNBytes* cData)
 void assign(sNBytes& cData, const Nakama::NBytes& data)
 {
     cData.bytes = (uint8_t*)data.data();
-    cData.size = (uint16_t)data.size();
+    cData.size = (uint32_t)data.size();
 }
 
 NStringMap toCppNStringMap(::NStringMap map)


### PR DESCRIPTION
Our packet size limit is 1mb, in particular for save game transfers.