### PR TITLE
Fix heroiclabs/nakama-unreal#47 by assigning the cursor in DataHelperC

### DIFF
--- a/src/nakama-c/DataHelperC.cpp
+++ b/src/nakama-c/DataHelperC.cpp
@@ -643,6 +643,7 @@ void assign(sNStorageObjectList& cObjList, const Nakama::NStorageObjectList& obj
 {
     cObjList.objects = nullptr;
     cObjList.objectsCount = (uint16_t)objList.objects.size();
+    cObjList.cursor = objList.cursor.c_str();
 
     if (cObjList.objectsCount > 0)
     {


### PR DESCRIPTION
See the [issue](https://github.com/heroiclabs/nakama-unreal/issues/47#issuecomment-808711815)

The cursor is missing, so uninitialized data was accessed.

I did not compile/test this fix.