### PR TITLE
Update boost download URL (bintray decom)

### DIFF
--- a/build/linux/install_deps.sh
+++ b/build/linux/install_deps.sh
@@ -5,7 +5,7 @@ sudo apt-get install -y build-essential autoconf libtool pkg-config wget
 sudo apt-get install -y libgflags-dev libgtest-dev
 sudo apt-get install -y clang libc++-dev golang perl
 mkdir -p build && cd build
-wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
+wget https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz
 tar xvzf boost_1_69_0.tar.gz
 cd boost_1_69_0
 ./bootstrap.sh --with-libraries=system,chrono,thread


### PR DESCRIPTION
Same version, just a new URL to get the source. Tested and compiles on Ubuntu 18.04