### PR TITLE
Missing Nakama-C implementation in NakamaWrapper is causing Party & Matchmaking callbacks to not trigger on the listener.

### DIFF
--- a/include/nakama-c/realtime/NRtClient.h
+++ b/include/nakama-c/realtime/NRtClient.h
@@ -582,7 +582,7 @@ extern "C" {
     /**
      * Called when either the user's party closes or the user is removed from the party.
      */
-    NAKAMA_API void NRtClient_setPartyCloseCallback(NRtClient client, void (*callback)(NRtClient));
+    NAKAMA_API void NRtClient_setPartyCloseCallback(NRtClient client, void (*callback)(NRtClient, const sNPartyClose* partyClose));
 
     /**
      * Called when the user receives custom party data.

--- a/include/nakama-cpp-c-wrapper/Impl/NDataHelperWrapperImpl.h
+++ b/include/nakama-cpp-c-wrapper/Impl/NDataHelperWrapperImpl.h
@@ -732,6 +732,12 @@ void assign(NStatusPresenceEvent& presence, const sNStatusPresenceEvent* cPresen
     assign(presence.leaves, cPresence->leaves, cPresence->leavesCount);
 }
 
+void assign(NPartyPresenceEvent& presence, const sNPartyPresenceEvent* partyPresence)
+{
+	assign(presence.joins, partyPresence->joins, partyPresence->joinsCount);
+	assign(presence.leaves, partyPresence->leaves, partyPresence->leavesCount);
+}
+
 void assign(NStream& stream, const sNStream* cStream)
 {
     stream.mode = cStream->mode;

--- a/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
+++ b/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
@@ -288,13 +288,13 @@ NAKAMA_NAMESPACE_BEGIN
             ::NRtClient_setMatchDataCallback(_cClient, &NRtClientWrapper::matchDataCallback);
             ::NRtClient_setMatchPresenceCallback(_cClient, &NRtClientWrapper::matchPresenceCallback);
             ::NRtClient_setNotificationsCallback(_cClient, &NRtClientWrapper::notificationsCallback);
-        	::NRtClient_setPartyCallback(_cClient, &NRtClientWrapper::partyCallback);
-        	::NRtClient_setPartyCloseCallback(_cClient, &NRtClientWrapper::partyClosedCallback);
+            ::NRtClient_setPartyCallback(_cClient, &NRtClientWrapper::partyCallback);
+            ::NRtClient_setPartyCloseCallback(_cClient, &NRtClientWrapper::partyClosedCallback);
             ::NRtClient_setStatusPresenceCallback(_cClient, &NRtClientWrapper::statusPresenceCallback);
-        	::NRtClient_setPartyJoinRequestCallback(_cClient, &NRtClientWrapper::partyJoinRequestCallback);
-        	::NRtClient_setPartyLeaderCallback(_cClient, &NRtClientWrapper::partyLeaderRequestCallback);
-        	::NRtClient_setPartyMatchmakerTicketCallback(_cClient, &NRtClientWrapper::partyMatchmakerTicketCallback);
-        	::NRtClient_setPartyPresenceCallback(_cClient, &NRtClientWrapper::partyPresenceCallback);
+            ::NRtClient_setPartyJoinRequestCallback(_cClient, &NRtClientWrapper::partyJoinRequestCallback);
+            ::NRtClient_setPartyLeaderCallback(_cClient, &NRtClientWrapper::partyLeaderRequestCallback);
+            ::NRtClient_setPartyMatchmakerTicketCallback(_cClient, &NRtClientWrapper::partyMatchmakerTicketCallback)
+	    ::NRtClient_setPartyPresenceCallback(_cClient, &NRtClientWrapper::partyPresenceCallback);
             ::NRtClient_setStreamPresenceCallback(_cClient, &NRtClientWrapper::streamPresenceCallback);
             ::NRtClient_setStreamDataCallback(_cClient, &NRtClientWrapper::streamDataCallback);
         }

--- a/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
+++ b/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
@@ -230,7 +230,16 @@ NAKAMA_NAMESPACE_BEGIN
                 wrapper->_listener->onPartyMatchmakerTicket(partyTicket);
             }
         }
-
+		static void partyPresenceCallback(NRtClient cClient, const sNPartyPresenceEvent* partyPresence)
+        {
+	        auto wrapper = getWrapper(cClient);
+        	if (wrapper->_listener)
+        	{
+        		NPartyPresenceEvent presence;
+        		assign(presence, partyPresence);
+        		wrapper->_listener->onPartyPresence(presence);
+        	}
+        }
 
 
         static void statusPresenceCallback(NRtClient cClient, const sNStatusPresenceEvent* cPresence)
@@ -279,7 +288,13 @@ NAKAMA_NAMESPACE_BEGIN
             ::NRtClient_setMatchDataCallback(_cClient, &NRtClientWrapper::matchDataCallback);
             ::NRtClient_setMatchPresenceCallback(_cClient, &NRtClientWrapper::matchPresenceCallback);
             ::NRtClient_setNotificationsCallback(_cClient, &NRtClientWrapper::notificationsCallback);
+        	::NRtClient_setPartyCallback(_cClient, &NRtClientWrapper::partyCallback);
+        	::NRtClient_setPartyCloseCallback(_cClient, &NRtClientWrapper::partyClosedCallback);
             ::NRtClient_setStatusPresenceCallback(_cClient, &NRtClientWrapper::statusPresenceCallback);
+        	::NRtClient_setPartyJoinRequestCallback(_cClient, &NRtClientWrapper::partyJoinRequestCallback);
+        	::NRtClient_setPartyLeaderCallback(_cClient, &NRtClientWrapper::partyLeaderRequestCallback);
+        	::NRtClient_setPartyMatchmakerTicketCallback(_cClient, &NRtClientWrapper::partyMatchmakerTicketCallback);
+        	::NRtClient_setPartyPresenceCallback(_cClient, &NRtClientWrapper::partyPresenceCallback);
             ::NRtClient_setStreamPresenceCallback(_cClient, &NRtClientWrapper::streamPresenceCallback);
             ::NRtClient_setStreamDataCallback(_cClient, &NRtClientWrapper::streamDataCallback);
         }


### PR DESCRIPTION
### Problem

Implementation of the Nakama-C  parties and matchmaking callbacks are missing in NakamaWrapper and can be reproduced with a simple example:

```c++
    NakamaWrapper::NClientPtr serverClient;
    NakamaWrapper:: NRtClientPtr serverRtClient;
    NakamaWrapper::NClientParameters parameters;
    NakamaWrapper::NRtDefaultClientListener serverListener;
    parameters.serverKey = "defaultkey";
    parameters.host = "localhost";
    parameters.port = 7350;
    parameters.ssl = false;
    serverClient = createDefaultClient(parameters);
    if (serverClient != nullptr) {
        std::cout << "INFO server initialized" << std::endl;
    }

    auto serverSuccessCallback = [this](const  NSessionPtr& session) {
        onServerAuthenticated(session);
    };

    constexpr bool create = true;
    const std::string serverName = "123456" + ".server";

    serverClient->authenticateCustom(serverName, serverName, create, {}, serverSuccessCallback, genericErrorCallback);

    while (true) {
        std::this_thread::sleep_for(std::chrono::milliseconds(200));
        if (serverClient) {
            serverClient->tick();
        }

        if (serverRtClient) {
            serverRtClient->tick();
        }

        if (shouldQuit) {
            return;
        }
    }
        serverRtClient = serverClient->createRtClient(7350);
        serverListener.setConnectCallback([this](){
        auto successCallback = [this](const  NakamaWrapper::NParty& party) {
           std::cout << "INFO server party created: " << party.id << std::endl;
        };

        std::cout << "INFO server rtClient connected" << std::endl;
     serverRtClient->createParty(true, 5, successCallback, genericRtErrorCallback);
    });
        serverListener.setPartyPresenceCallback([this](const  NakamaWrapper::NPartyPresenceEvent& presenceEvent) {
        this->simpleFunction();
        std::cout << "INFO party presence event for party " << presenceEvent.partyId << std::endl;

        for (const  NakamaWrapper::NUserPresence& presence: presenceEvent.joins)
            std::cout << "INFO joins " << presence.username << " with session " << presence.sessionId << std::endl;

        for (const  NakamaWrapper::NUserPresence& presence : presenceEvent.leaves) {
            std::cout << "INFO leaves " << presence.username << " with session " << presence.sessionId << std::endl;
        }
    });

    serverRtClient->setListener(&serverListener);
    serverRtClient->connect(session, true);

```
### Pull request details

This pull request implements:

- missing implementation of party, partyClose, partyJoin, partyMatchmakerTicket and partyPresence from their C typedef declaration 
- adds NPartyClose message that was missing from partyCloseCallback 
- partyPresenceCallback type conversion helper.

### Test 

Re-running the example should fire the appropriate callback. In the future, it would be useful if more functions could be added to wrapper-tests as their test surface is pretty bare at the moment. 