### PR TITLE
Fix missing implementation of partyClose and conflicting declarations

### DIFF
--- a/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
+++ b/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
@@ -294,7 +294,7 @@ NAKAMA_NAMESPACE_BEGIN
             ::NRtClient_setPartyJoinRequestCallback(_cClient, &NRtClientWrapper::partyJoinRequestCallback);
             ::NRtClient_setPartyLeaderCallback(_cClient, &NRtClientWrapper::partyLeaderRequestCallback);
             ::NRtClient_setPartyMatchmakerTicketCallback(_cClient, &NRtClientWrapper::partyMatchmakerTicketCallback);
-	        ::NRtClient_setPartyPresenceCallback(_cClient, &NRtClientWrapper::partyPresenceCallback);
+            ::NRtClient_setPartyPresenceCallback(_cClient, &NRtClientWrapper::partyPresenceCallback);
             ::NRtClient_setStreamPresenceCallback(_cClient, &NRtClientWrapper::streamPresenceCallback);
             ::NRtClient_setStreamDataCallback(_cClient, &NRtClientWrapper::streamDataCallback);
         }

--- a/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
+++ b/include/nakama-cpp-c-wrapper/Impl/NRtClientWrapperImpl.h
@@ -293,8 +293,8 @@ NAKAMA_NAMESPACE_BEGIN
             ::NRtClient_setStatusPresenceCallback(_cClient, &NRtClientWrapper::statusPresenceCallback);
             ::NRtClient_setPartyJoinRequestCallback(_cClient, &NRtClientWrapper::partyJoinRequestCallback);
             ::NRtClient_setPartyLeaderCallback(_cClient, &NRtClientWrapper::partyLeaderRequestCallback);
-            ::NRtClient_setPartyMatchmakerTicketCallback(_cClient, &NRtClientWrapper::partyMatchmakerTicketCallback)
-	    ::NRtClient_setPartyPresenceCallback(_cClient, &NRtClientWrapper::partyPresenceCallback);
+            ::NRtClient_setPartyMatchmakerTicketCallback(_cClient, &NRtClientWrapper::partyMatchmakerTicketCallback);
+	        ::NRtClient_setPartyPresenceCallback(_cClient, &NRtClientWrapper::partyPresenceCallback);
             ::NRtClient_setStreamPresenceCallback(_cClient, &NRtClientWrapper::streamPresenceCallback);
             ::NRtClient_setStreamDataCallback(_cClient, &NRtClientWrapper::streamDataCallback);
         }

--- a/src/DataHelper.cpp
+++ b/src/DataHelper.cpp
@@ -482,7 +482,7 @@ void assign(NPartyJoinRequest& partyJoinRequest, const ::nakama::realtime::Party
     assign(partyJoinRequest.presences, data.presences());
 }
 
-void assign(NPartyClose & partyClose,  const::nakama::realtime::PartyClose & data)
+void assign(NPartyClose& partyClose,  const::nakama::realtime::PartyClose & data)
 {
     assign(partyClose.id, data.party_id());
 }

--- a/src/DataHelper.cpp
+++ b/src/DataHelper.cpp
@@ -482,7 +482,7 @@ void assign(NPartyJoinRequest& partyJoinRequest, const ::nakama::realtime::Party
     assign(partyJoinRequest.presences, data.presences());
 }
 
-void assign(NPartyClose& partyClose,  const::nakama::realtime::PartyClose & data)
+void assign(NPartyClose & partyClose,  const::nakama::realtime::PartyClose & data)
 {
     assign(partyClose.id, data.party_id());
 }

--- a/src/nakama-c/DataHelperC.cpp
+++ b/src/nakama-c/DataHelperC.cpp
@@ -800,6 +800,11 @@ void assign(sNStatus& cStatus, const Nakama::NStatus& status)
     assign(cStatus.presences, cStatus.presencesCount, status.presences);
 }
 
+void assign(sNPartyClose& cPartyClose, const Nakama::NPartyClose& partyCloseEvent)
+{
+    cPartyClose.id = partyCloseEvent.id.c_str();
+}
+
 void assign(sNParty& cParty, const Nakama::NParty& party)
 {
     cParty.id = party.id.c_str();

--- a/src/nakama-c/DataHelperC.h
+++ b/src/nakama-c/DataHelperC.h
@@ -163,6 +163,7 @@ void assign(sNStatusPresenceEvent& cEvent, const Nakama::NStatusPresenceEvent& e
 void assign(sNStream& cStream, const Nakama::NStream& stream);
 void assign(sNStreamPresenceEvent& cEvent, const Nakama::NStreamPresenceEvent& event);
 void assign(sNStreamData& cData, const Nakama::NStreamData& data);
+void assign(sNPartyClose& cPartyClose, const Nakama::NPartyClose& partyClose);
 void assign(sNParty& cParty, const Nakama::NParty& party);
 void assign(sNPartyPresenceEvent& cEvent, const Nakama::NPartyPresenceEvent& event);
 void assign(sNPartyData& cData, const Nakama::NPartyData& partyData);

--- a/src/nakama-c/realtime/NRtClientC.cpp
+++ b/src/nakama-c/realtime/NRtClientC.cpp
@@ -912,15 +912,17 @@ void NRtClient_setPartyCallback(NRtClient client, void (*callback)(NRtClient, co
         listener->setPartyCallback(nullptr);
 }
 
-void NRtClient_setPartyCloseCallback(NRtClient client, void (*callback)(NRtClient))
+void NRtClient_setPartyCloseCallback(NRtClient client, void (*callback)(NRtClient, const sNPartyClose* partyClose))
 {
     auto listener = Nakama::getRtClientListener(client);
 
     if (callback)
     {
-        listener->setPartyCloseCallback([client, callback](const Nakama::NPartyClose& party)
+        listener->setPartyCloseCallback([client, callback](const Nakama::NPartyClose& partyClose)
         {
-            callback(client);
+            sNPartyClose cParty;
+            assign(cParty, partyClose);
+            callback(client, &cParty);
         });
     }
     else


### PR DESCRIPTION
Fixes static build failures https://github.com/heroiclabs/nakama-cpp/runs/4422728680?check_suite_focus=true

Compiles here fine now:

```
building nakama-cpp...
calling: ['cmake', '--build', 'C:\\Users\\rpomy\\Documents\\Projects\\nakama-cpp\\build\\windows\\build\\v142_x64', '--target', 'nakama-cpp', '--config', 'Release', '--parallel', '12']
Microsoft (R) Build Engine version 16.11.2+f32259642 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  ssl.vcxproj -> C:\Users\rpomy\Documents\Projects\nakama-cpp\build\windows\build\v142_x64\third_party\grpc\third_party\boringssl-with-bazel\Release\ssl.lib
  libprotobuf.vcxproj -> C:\Users\rpomy\Documents\Projects\nakama-cpp\build\windows\build\v142_x64\third_party\grpc\third_party\protobuf\Release\libprotobuf.lib
  cpprest.vcxproj -> C:\Users\rpomy\Documents\Projects\nakama-cpp\build\windows\build\v142_x64\third_party\cpprestsdk\Release\Binaries\Release\cpprest.lib
  crypto.vcxproj -> C:\Users\rpomy\Documents\Projects\nakama-cpp\build\windows\build\v142_x64\third_party\grpc\third_party\boringssl-with-bazel\Release\crypto.lib
  BaseClient.cpp
  ClientFactory.cpp
  DataHelper.cpp
  DefaultSession.cpp
  GrpcClient.cpp
  NError.cpp
  NHttpClientCppRest.cpp
  NUtils.cpp
  Nakama.cpp
  RestClient.cpp
  StrUtil.cpp
  apigrpc.pb.cc
  api.pb.cc
  realtime.pb.cc
  http.pb.cc
  any.pb.cc
  descriptor.pb.cc
  empty.pb.cc
  struct.pb.cc
  timestamp.pb.cc
  Generating Code...
  Compiling...
  wrappers.pb.cc
  openapiv2.pb.cc
  NConsoleLogSink.cpp
  NLogger.cpp
  ClientFactoryC.cpp
  DataHelperC.cpp
  NClientC.cpp
  NSessionC.cpp
  NStringDoubleMapC.cpp
  NStringMapC.cpp
  NakamaC.cpp
  NLoggerC.cpp
  NRtClientC.cpp
  NRtClient.cpp
  NRtClientProtocol_Json.cpp
  NRtClientProtocol_Protobuf.cpp
  NRtError.cpp
  NWebsocketCppRest.cpp
  NWebsocketsFactory.cpp
  roots_pem.cpp
  Generating Code...
  annotations.pb.cc
  annotations.pb.cc
  android.cpp
  android.cpp
     Creating library C:/Users/rpomy/Documents/Projects/nakama-cpp/build/windows/build/v142_x64/src/Release/nakama-cpp.lib and object C:/Users/rpomy/Documents/Projects/nakama-cpp/build/wi
  ndows/build/v142_x64/src/Release/nakama-cpp.exp
  nakama-cpp.vcxproj -> C:\Users\rpomy\Documents\Projects\nakama-cpp\build\windows\build\v142_x64\src\Release\nakama-cpp.dll
release_libs_path: C:\Users\rpomy\Documents\Projects\nakama-cpp\release\nakama-cpp-sdk\shared-libs\win64\v142\Release
copying to release folder...
copied nakama-cpp.lib
copied nakama-cpp.dll

building nakama-test...
calling: ['cmake', '--build', 'C:\\Users\\rpomy\\Documents\\Projects\\nakama-cpp\\build\\windows\\build\\v142_x64', '--target', 'nakama-test', '--config', 'Release', '--parallel', '12']
Microsoft (R) Build Engine version 16.11.2+f32259642 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  TaskExecutor.cpp
  c-test.cpp
  c-test_authentication.cpp
  c-test_realtime.cpp
  RtClientTestBase.cpp
  test_authoritative_match.cpp
  test_match.cpp
  test_notifications.cpp
  test_parties.cpp
  test_realtime.cpp
  test_rpc.cpp
  test_tournament.cpp
  test_authentication.cpp
  test_base.cpp
  test_disconnect.cpp
  test_errors.cpp
  test_getAccount.cpp
  test_groups.cpp
  test_main.cpp
  test_restoreSession.cpp
  Generating Code...
  Compiling...
  test_storage.cpp
  wrapper-test.cpp
  wrapper-test_account.cpp
  wrapper-test_authentication.cpp
  wrapper-test_match.cpp
  wrapper-test_realtime.cpp
  Generating Code...
  c-test-pure.c
  nakama-test.vcxproj -> C:\Users\rpomy\Documents\Projects\nakama-cpp\build\windows\build\v142_x64\test\Release\nakama-test.exe
done.
```