### PR TITLE
Perform disconnect() after wslay_event_read when remotely disconnected

### DIFF
--- a/impl/wsWslay/NWebsocketWslay.cpp
+++ b/impl/wsWslay/NWebsocketWslay.cpp
@@ -198,6 +198,7 @@ namespace Nakama {
 
     template<typename IO>
     void NWebsocketWslay<IO>::connect(const std::string& url, NRtTransportType transportType) {
+        std::lock_guard(this->_lifecycle_lock);
         assert(!_ctx);
         {
             wslay_event_context_ptr p;
@@ -233,6 +234,8 @@ namespace Nakama {
 
     template<typename IO>
     void NWebsocketWslay<IO>::disconnect(bool remote) {
+        std::lock_guard(this->_lifecycle_lock);
+
         if (!remote && _state == State::Connected) {
             assert(_ctx);
             // we've asked for disconnect, send close frame before closing socket
@@ -262,6 +265,8 @@ namespace Nakama {
 
     template<typename IO>
     bool NWebsocketWslay<IO>::send(const NBytes& data) {
+        std::lock_guard(this->_lifecycle_lock);
+
         struct wslay_event_msg msg{
             _opcode,
             reinterpret_cast<const uint8_t*>(&data[0]),
@@ -285,6 +290,8 @@ namespace Nakama {
 
     template<typename IO>
     void NWebsocketWslay<IO>::tick() {
+        std::lock_guard(this->_lifecycle_lock);
+
         // most common case
         if (_state == State::Connected) {
             int ret = wslay_event_recv(_ctx.get());

--- a/impl/wsWslay/NWebsocketWslay.cpp
+++ b/impl/wsWslay/NWebsocketWslay.cpp
@@ -185,7 +185,7 @@ namespace Nakama {
             nullptr,
             on_msg_recv_callback
         },
-        _ctx(nullptr, wslay_event_context_free)
+        _ctx(nullptr, wslay_event_context_free), _state(State::Disconnected)
     {}
 
     template<typename IO>

--- a/impl/wsWslay/NWebsocketWslay.cpp
+++ b/impl/wsWslay/NWebsocketWslay.cpp
@@ -304,6 +304,7 @@ namespace Nakama {
             return;
         }
 
+        // this is set if the wslay_event_recv above reads a close frame.
         if (_state == State::RemoteDisconnect) {
             disconnect(true);
         }

--- a/impl/wsWslay/NWebsocketWslay.cpp
+++ b/impl/wsWslay/NWebsocketWslay.cpp
@@ -288,16 +288,20 @@ namespace Nakama {
         // most common case
         if (_state == State::Connected) {
             int ret = wslay_event_recv(_ctx.get());
-            if (ret != 0)
-            {
+
+            // disconnect() may have been called in on_msg_recv_callback()
+            if (_state == State::Disconnected) {
+                return;
+            }
+
+            if (ret != 0) {
                 NLOG(NLogLevel::Error, "[wslay] unable to receive message from peer: %d", ret);
                 disconnect(false);
                 return;
             }
 
             ret = wslay_event_send(_ctx.get());
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 NLOG(NLogLevel::Error, "[wslay] unable to send message to peer: %d", ret);
                 disconnect(false);
                 return;

--- a/impl/wsWslay/NWebsocketWslay.h
+++ b/impl/wsWslay/NWebsocketWslay.h
@@ -18,7 +18,6 @@
 
 #include <string>
 #include <memory>
-#include <mutex>
 #include <wslay/wslay.h>
 #include "nakama-cpp/realtime/NRtTransportInterface.h"
 #include "StrUtil.h"

--- a/impl/wsWslay/NWebsocketWslay.h
+++ b/impl/wsWslay/NWebsocketWslay.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <memory>
+#include <mutex>
 #include <wslay/wslay.h>
 #include "nakama-cpp/realtime/NRtTransportInterface.h"
 #include "StrUtil.h"
@@ -74,6 +75,9 @@ private:
     //Http send state
     std::string _buf;
     std::string::iterator _buf_iter;
+    // lock each function in the connect/tick/send/disconnect lifecycle functions to prevent bad race conditions.
+    std::mutex _lifecycle_lock;
+
 };
 
 }

--- a/impl/wsWslay/NWebsocketWslay.h
+++ b/impl/wsWslay/NWebsocketWslay.h
@@ -27,11 +27,12 @@
 namespace Nakama {
 
 enum class State {
+    RemoteDisconnect,
     Disconnected,
     Connecting,
     Handshake_Sending,
     Handshake_Receiving,
-    Connected,
+    Connected
 };
 
 template<typename IO>
@@ -75,9 +76,6 @@ private:
     //Http send state
     std::string _buf;
     std::string::iterator _buf_iter;
-    // lock each function in the connect/tick/send/disconnect lifecycle functions to prevent bad race conditions.
-    std::mutex _lifecycle_lock;
-
 };
 
 }

--- a/test/src/realtime/RtClientTestBase.cpp
+++ b/test/src/realtime/RtClientTestBase.cpp
@@ -49,7 +49,7 @@ void NRtClientTest::runTest()
 
     listener.setDisconnectCallback([this](const NRtClientDisconnectInfo &/*info*/)
     {
-        if (!isDone())
+        if (!isDone() && this->_stopTestOnDisconnect)
         {
             stopTest();
         }
@@ -122,6 +122,11 @@ void NRtClientTest::tick()
 void NRtClientTest::setRtTickPaused(bool paused)
 {
     this->_rtTickPaused = paused;
+}
+
+void NRtClientTest::setRtStopTestOnDisconnect(bool stopTest)
+{
+    this->_stopTestOnDisconnect = stopTest;
 }
 
 } // namespace Test

--- a/test/src/realtime/RtClientTestBase.cpp
+++ b/test/src/realtime/RtClientTestBase.cpp
@@ -113,10 +113,15 @@ void NRtClientTest::tick()
 {
     NCppTest::tick();
 
-    if (rtClient)
+    if (rtClient && !this->_rtTickPaused)
     {
         rtClient->tick();
     }
+}
+
+void NRtClientTest::setRtTickPaused(bool paused)
+{
+    this->_rtTickPaused = paused;
 }
 
 } // namespace Test

--- a/test/src/realtime/RtClientTestBase.h
+++ b/test/src/realtime/RtClientTestBase.h
@@ -44,7 +44,12 @@ public:
 
     std::function<bool()> onTimeoutCb;
 
+    void setRtTickPaused(bool paused);
+
     void tick() override;
+
+private:
+    bool _rtTickPaused;
 };
 
 } // namespace Test

--- a/test/src/realtime/RtClientTestBase.h
+++ b/test/src/realtime/RtClientTestBase.h
@@ -23,7 +23,9 @@ namespace Test {
 class NRtClientTest : public NCppTest
 {
 public:
-    NRtClientTest(const char* name) : NCppTest(name) {}
+    NRtClientTest(const char* name) : NCppTest(name) {
+        this->setRtStopTestOnDisconnect(true);
+    }
 
     std::function<void()> onRtConnect;
 
@@ -45,11 +47,13 @@ public:
     std::function<bool()> onTimeoutCb;
 
     void setRtTickPaused(bool paused);
+    void setRtStopTestOnDisconnect(bool stopTest);
 
     void tick() override;
 
 private:
     bool _rtTickPaused;
+    bool _stopTestOnDisconnect;
 };
 
 } // namespace Test

--- a/test/src/realtime/RtClientTestBase.h
+++ b/test/src/realtime/RtClientTestBase.h
@@ -23,8 +23,8 @@ namespace Test {
 class NRtClientTest : public NCppTest
 {
 public:
-    NRtClientTest(const char* name) : NCppTest(name) {
-        this->setRtStopTestOnDisconnect(true);
+    NRtClientTest(const char* name) : NCppTest(name), _rtTickPaused(false), _stopTestOnDisconnect(true) {
+
     }
 
     std::function<void()> onRtConnect;

--- a/test/src/realtime/test_realtime.cpp
+++ b/test/src/realtime/test_realtime.cpp
@@ -127,7 +127,7 @@ void test_rt_heartbeat()
 void test_rt_remote_disconnect()
 {
     NRtClientTest test(__func__);
-    // test what
+    // we want to test behavior of socket after disconnect.
     test.setRtStopTestOnDisconnect(false);
     test.setTestTimeoutMs(15000);
     test.onRtConnect = [&test]()

--- a/test/src/realtime/test_realtime.cpp
+++ b/test/src/realtime/test_realtime.cpp
@@ -122,6 +122,32 @@ void test_rt_heartbeat()
     test.runTest();
 }
 
+void test_rt_sleep_tick()
+{
+    NRtClientTest test(__func__);
+
+    test.setTestTimeoutMs(100000);
+    test.onRtConnect = [&test]()
+    {
+        test.rtClient->createMatch([&test](const Nakama::NMatch& match)
+        {
+            std::cout << "created match" << std::endl;
+            std::cout << "about to sleep" << std::endl;
+            test.setRtTickPaused(true);
+            sleep(90000);
+            test.setRtTickPaused(false);
+            std::cout << "done sleeping" << std::endl;
+
+            test.rtClient->leaveMatch(match.matchId, [&test](){
+                test.stopTest(true);
+            });
+        });
+    };
+
+    test.runTest();
+}
+
+
 void test_rt_joinChat()
 {
     NRtClientTest test(__func__);

--- a/test/src/realtime/test_realtime.cpp
+++ b/test/src/realtime/test_realtime.cpp
@@ -126,7 +126,7 @@ void test_rt_sleep_tick()
 {
     NRtClientTest test(__func__);
 
-    test.setTestTimeoutMs(100000);
+    test.setTestTimeoutMs(20000);
     test.onRtConnect = [&test]()
     {
         test.rtClient->createMatch([&test](const Nakama::NMatch& match)
@@ -134,7 +134,7 @@ void test_rt_sleep_tick()
             std::cout << "created match" << std::endl;
             std::cout << "about to sleep" << std::endl;
             test.setRtTickPaused(true);
-            sleep(90000);
+            sleep(10000);
             test.setRtTickPaused(false);
             std::cout << "done sleeping" << std::endl;
 
@@ -263,6 +263,7 @@ void run_realtime_tests()
 
 void test_realtime()
 {
+    test_rt_sleep_tick();
     // These tests are not protocol specific
     test_rt_quickdestroy();
     test_rt_rapiddisconnect();

--- a/test/src/realtime/test_realtime.cpp
+++ b/test/src/realtime/test_realtime.cpp
@@ -122,6 +122,8 @@ void test_rt_heartbeat()
     test.runTest();
 }
 
+// optional test -- pass --socket.pong_wait_ms 5000 to Nakama so that it disconnects rtclient after sleep
+// in order to test how it will react.
 void test_rt_remote_disconnect()
 {
     NRtClientTest test(__func__);
@@ -132,16 +134,11 @@ void test_rt_remote_disconnect()
     {
         test.rtClient->createMatch([&test](const Nakama::NMatch& match)
         {
-            std::cout << "created match" << std::endl;
-            std::cout << "about to sleep" << std::endl;
             test.setRtTickPaused(true);
             sleep(10000);
             test.setRtTickPaused(false);
-            std::cout << "done sleeping" << std::endl;
-
-            test.rtClient->leaveMatch(match.matchId, [&test](){
-                test.stopTest(true);
-            });
+            sleep(1000);
+            test.stopTest(true);
         });
     };
 
@@ -264,7 +261,6 @@ void run_realtime_tests()
 
 void test_realtime()
 {
-    test_rt_remote_disconnect();
     // These tests are not protocol specific
     test_rt_quickdestroy();
     test_rt_rapiddisconnect();

--- a/test/src/realtime/test_realtime.cpp
+++ b/test/src/realtime/test_realtime.cpp
@@ -122,11 +122,12 @@ void test_rt_heartbeat()
     test.runTest();
 }
 
-void test_rt_sleep_tick()
+void test_rt_remote_disconnect()
 {
     NRtClientTest test(__func__);
-
-    test.setTestTimeoutMs(20000);
+    // test what
+    test.setRtStopTestOnDisconnect(false);
+    test.setTestTimeoutMs(15000);
     test.onRtConnect = [&test]()
     {
         test.rtClient->createMatch([&test](const Nakama::NMatch& match)
@@ -263,7 +264,7 @@ void run_realtime_tests()
 
 void test_realtime()
 {
-    test_rt_sleep_tick();
+    test_rt_remote_disconnect();
     // These tests are not protocol specific
     test_rt_quickdestroy();
     test_rt_rapiddisconnect();


### PR DESCRIPTION
If the socket was remotely disconnected, the wslay context would be reset from within the wslay_event_read call because we immediately call disconnect() upon receiving a close frame https://github.com/heroiclabs/nakama-cpp/compare/luke/tick?expand=1#diff-0a230c967b82d8b2272c6104259685dc6db24050c0a9473b59bd852f9ca65ed5L290

This would cause a bad access.

I looked at a few different options but ultimately landed on adding a new state to the state machine so that the client can perform it's final disconnection logic in the next `tick()`. But there are probably a few different valid ways of solving this.

- [x] Backport to nakama-cpp-mono