### PR TITLE
Trigger onDisconnect callback on wslay errors

### DIFF
--- a/impl/wsWslay/NWebsocketWslay.h
+++ b/impl/wsWslay/NWebsocketWslay.h
@@ -60,7 +60,7 @@ private:
     NetIOAsyncResult http_handshake_init();
     NetIOAsyncResult http_handshake_send();
     NetIOAsyncResult http_handshake_receive();
-    void disconnect(bool remote);
+    void disconnect(bool remote, std::optional<uint16_t> code);
 
     IO io;
     struct wslay_event_callbacks _callbacks;

--- a/interface/include/nakama-cpp/realtime/NRtClientDisconnectInfo.h
+++ b/interface/include/nakama-cpp/realtime/NRtClientDisconnectInfo.h
@@ -37,7 +37,8 @@ NAKAMA_NAMESPACE_BEGIN
             INTERNAL_SERVER_ERROR = 1011,
             TLS_HANDSHAKE = 1015,
 
-            HEARTBEAT_FAILURE = 4000
+            HEARTBEAT_FAILURE = 4000,
+            TRANSPORT_ERROR = 4001
         };
 
         /// close code.


### PR DESCRIPTION
disconnect's `remote` argument actually means "transport initiated" when true and  "client initiated" when false. wslay error causes disconnect from the transport side (even though remote side didn't sent us close frame), therefore should be calling `this->disconnect(true)`