### PR TITLE
Optionally include optional-lite in builds (ON by default, OFF for vcpkg consumers)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ install(FILES
 if (INCLUDE_OPTIONAL_LITE)
     install(DIRECTORY
         ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nonstd
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set(WS_IMPL OFF CACHE STRING "Websocket implementation. One of: ${WEBSOCKET_IMPL
 set(HTTP_IMPLS libhttpclient OFF)
 set(HTTP_IMPL OFF CACHE STRING "HTTP implementation. One of: ${HTTP_IMPLS}")
 
+# By default, assume user will not obtain optional-lite via third party mechanism.
+option(INCLUDE_OPTIONAL_LITE "Include optional lite in include folder" ON)
+
 option(UNREAL "Unreal engine support" OFF)
 
 if (UNREAL)
@@ -333,6 +336,13 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/nakama-sdk-config.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/nakama
 )
+
+if (INCLUDE_OPTIONAL_LITE)
+    install(DIRECTORY
+        ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nonstd
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/include
+    )
+endif()
 
 # Call last so that it can reference any target previously defined
 include(cmake/linkerFlagsTargets.cmake)

--- a/cmake/vcpkg-ports/nakama-sdk/portfile.cmake
+++ b/cmake/vcpkg-ports/nakama-sdk/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
-        --DINCLUDE_OPTIONAL_LITE=OFF
+        --DINCLUDE_OPTIONAL_LITE=OFF # user will obtain optional-lite via vcpkg dependency management
 )
 
 vcpkg_cmake_install()

--- a/cmake/vcpkg-ports/nakama-sdk/portfile.cmake
+++ b/cmake/vcpkg-ports/nakama-sdk/portfile.cmake
@@ -5,5 +5,9 @@ vcpkg_from_github(
     SHA512 05446f2a59947afcfd029be62c7639566765f2dc1564982b6d5366ebf60f4be6a4539d1caaa0ab20d27bb8b4a806862ddcb1d5bd0007b7a28eb26e0f10bf0164
 )
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        --DINCLUDE_OPTIONAL_LITE=OFF
+)
+
 vcpkg_cmake_install()


### PR DESCRIPTION
We keep the include flag on by default for users not using vcpkg, which is the vast majority of our users. We turn it off when nakama-cpp is being consumed by vcpkg users because it's listed as a typical vcpkg dependency.

Depends on #74 