### PR TITLE
fix git tree

### DIFF
--- a/versions/n-/nakama-sdk.json
+++ b/versions/n-/nakama-sdk.json
@@ -3,7 +3,7 @@
 		{
 			"version": "2.6.0",
 			"port-version": 3,
-			"git-tree": "3c353890dc190593ff03429184c3c0f762dd949f"
+			"git-tree": "5b1268212af5982ca0d90b50165b350137a097d1"
 		}
 	]
 }


### PR DESCRIPTION
I don't know how this got out of sync. It is the git tree hash of the directory containing the nakama sdk portfile so that it can be fetched from vcokg.