### PR TITLE
split out ci workflows into separate scripts

### DIFF
--- a/.github/actions/cmake-build/action.yml
+++ b/.github/actions/cmake-build/action.yml
@@ -8,9 +8,6 @@ inputs:
     description: 'Build config: MinSizeRel or Debug'
     required: true
     default: 'MinSizeRel'
-  flavour:
-    description: 'Possible values: Unreal, libcxx'
-    required: false
   artifact_retention_days:
     description: 'Artifact retention days'
     default: 2
@@ -51,18 +48,6 @@ runs:
         $( type -p mono || :) `vcpkg fetch nuget | tail -n 1`
         setapikey "${{ inputs.GITHUB_TOKEN }}"
         -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-    - id: cmake_args
-      shell: bash
-      if: ${{ inputs.flavour }}
-      run: |
-        if [[ "${{inputs.flavour}}" == "Unreal" ]]; then
-          echo "::set-output name=args::-DUNREAL=ON"
-        elif [[ "${{inputs.flavour}}" == "libcxx" ]]; then
-          echo "::set-output name=args::-DWITH_LIBCXX=ON"
-        else
-          echo "::error::Unexpected 'input' flavour value: ${{ inputs.flavour }}"
-        fi
-
     - name: Installing prerequisites
       run:  |
         if [[ "${{ runner.os }}"  == "Linux" ]]; then

--- a/.github/actions/cmake-build/action.yml
+++ b/.github/actions/cmake-build/action.yml
@@ -89,11 +89,7 @@ runs:
         preset="${{ inputs.preset }}"
         # strip -host_{arm64,x64} from the preset, because it is not relevant for users
         preset=${preset%-host_*}
-        if [[ -n "${{ inputs.flavour }}" ]]; then
-          name="libnakama-${{ inputs.flavour }}-${preset}-${{ inputs.build_type }}-git.${sha:0:8}"
-        else
-          name="libnakama-${preset}-${{ inputs.build_type }}-git.${sha:0:8}"
-        fi
+        name="libnakama-${preset}-${{ inputs.build_type }}-git.${sha:0:8}"
         echo "::set-output name=artifact::${name}"
     #
     - run: >

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,0 +1,15 @@
+name: Build Android
+on: [workflow_call, workflow_dispatch]
+jobs:
+  android_matrix:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        preset: ["android-armeabi-v7a-host_osx_x64", "android-arm64-v8a-host_osx_x64", "android-x64-host_osx_x64"]
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cmake-build
+        with:
+          preset: ${{ matrix.preset }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -1,0 +1,15 @@
+name: Build iOS
+on: [workflow_call, workflow_dispatch]
+jobs:
+  ios_matrix:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        preset: ["ios-arm64-host_x64", "iphonesimulator-x64-host_x64"]
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cmake-build
+        with:
+          preset: ${{ matrix.preset }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,14 @@
+name: Build Linux
+on: [workflow_call, workflow_dispatch]
+jobs:
+  linux_matrix:
+    timeout-minutes: 30
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cmake-build
+        with:
+          preset: linux-amd64
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -11,4 +11,3 @@ jobs:
           preset: linux-amd64
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -1,0 +1,15 @@
+name: Build OSX
+on: [workflow_call, workflow_dispatch]
+jobs:
+  osx_matrix:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        preset: ["ios-arm64-host_x64", "iphonesimulator-x64-host_x64", "macosx-x64-host_x64", "macosx-arm64-host_x64"]
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cmake-build
+        with:
+          preset: ${{ matrix.preset }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,16 @@
+name: Build Windows
+on: [workflow_call, workflow_dispatch]
+jobs:
+  windows_matrix:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        build_type: [MinSizeRel, Debug]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cmake-build
+        with:
+          preset: win-x64
+          build_type: ${{ matrix.build_type }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/buildall.yml
+++ b/.github/workflows/buildall.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: ./.github/actions/cmake-build
         with:
           preset: linux-amd64
-          flavour: ${{ matrix.flavour }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   android_matrix:

--- a/.github/workflows/buildall.yml
+++ b/.github/workflows/buildall.yml
@@ -15,21 +15,8 @@ jobs:
           build_type: ${{ matrix.build_type }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Unreal Engine doesn't officially support debug (/MDd flag) builds,
-      # so we build Unreal flavour in release config only
-      - if: ${{ matrix.build_type == 'MinSizeRel' }}
-        uses: ./.github/actions/cmake-build
-        with:
-          preset: win-x64
-          build_type: ${{ matrix.build_type }}
-          flavour: Unreal
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   linux_matrix:
     timeout-minutes: 30
-    strategy:
-      matrix:
-        flavour: [ "", "libcxx" ]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
@@ -39,13 +26,6 @@ jobs:
           flavour: ${{ matrix.flavour }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Once libc++ version is built, same build tree can be reused for Unreal
-      - if: matrix.flavour == 'libcxx'
-        uses: ./.github/actions/cmake-build
-        with:
-          preset: linux-amd64
-          flavour: Unreal
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   android_matrix:
     timeout-minutes: 30
     strategy:
@@ -59,13 +39,6 @@ jobs:
           preset: ${{ matrix.preset }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Unreal module
-        uses: ./.github/actions/cmake-build
-        with:
-          preset: ${{ matrix.preset }}
-          flavour: Unreal
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   apple_matrix:
     timeout-minutes: 30
     strategy:
@@ -77,12 +50,6 @@ jobs:
       - uses: ./.github/actions/cmake-build
         with:
           preset: ${{ matrix.preset }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Unreal module
-        uses: ./.github/actions/cmake-build
-        with:
-          preset: ${{ matrix.preset }}
-          flavour: Unreal
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   combine:
@@ -118,18 +85,10 @@ jobs:
       - name: Prepare artifacts archives
         run: |
           (
-            cd ./${{ steps.combine.outputs.unreal-artifact-dir }}
-            7zr a ../${{ steps.combine.outputs.unreal-artifact-name }}.7z '*'
-          )
-          (
             cd ./${{ steps.combine.outputs.generic-artifact-dir }}
             7zr a ../${{ steps.combine.outputs.generic-artifact-name }}.7z '*'
           )
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.combine.outputs.unreal-artifact-name }}
-          path: ./${{ steps.combine.outputs.unreal-artifact-dir }}.7z
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.combine.outputs.generic-artifact-name }}

--- a/.github/workflows/buildall.yml
+++ b/.github/workflows/buildall.yml
@@ -1,58 +1,18 @@
 name: Build All
 on: [workflow_call, workflow_dispatch]
 jobs:
-  windows_matrix:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        build_type: [MinSizeRel, Debug]
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/cmake-build
-        with:
-          preset: win-x64
-          build_type: ${{ matrix.build_type }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  linux_matrix:
-    timeout-minutes: 30
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/cmake-build
-        with:
-          preset: linux-amd64
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   android_matrix:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        preset: ["android-armeabi-v7a-host_osx_x64", "android-arm64-v8a-host_osx_x64", "android-x64-host_osx_x64"]
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/cmake-build
-        with:
-          preset: ${{ matrix.preset }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  apple_matrix:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        preset: ["ios-arm64-host_x64", "iphonesimulator-x64-host_x64", "macosx-x64-host_x64", "macosx-arm64-host_x64"]
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/cmake-build
-        with:
-          preset: ${{ matrix.preset }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+    uses: ./android_matrix.yml
+  ios_matrix:
+    uses: ./ios_matrix.yml
+  linux_matrix:
+    uses: ./linux_matrix.yml
+  osx_matrix:
+    uses: ./osx_matrix.yml
+  windows_matrix:
+    uses: ./osx_matrix.yml
   combine:
-    needs: [android_matrix, windows_matrix, linux_matrix, apple_matrix]
+    needs: [android_matrix, ios_matrix, linux_matrix, osx_matrix, windows_matrix]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/ci/combine-artifacts.sh
+++ b/ci/combine-artifacts.sh
@@ -13,26 +13,6 @@ find_git_sha() {
   git_sha="${one##*-git.}"
 }
 
-prep_unreal_osx_universal() {
-  echo '::group::Prepare Unreal OSX universal binaries'
-  # output dir is in artifacts dir and name is chosen so that combine_unreal finds it
-  local out=${artifacts_dir}/libnakama-Unreal-macosx-universal-git.${git_sha}
-  mkdir -p ${out}
-
-  # Everything, but library should be identical. Copy one arch and then delete lib
-  # TODO: dont expect arm64 to always be present, pick first match instead
-  cp -rf ${artifacts_dir}/libnakama-Unreal-macosx-arm64*-git.${git_sha}/* ${out}/
-  rm -rf ${out}/Nakama/libnakama/macosx-arm64/nakama-sdk.framework/Versions/A/nakama-sdk
-  mv ${out}/Nakama/libnakama/macosx-{arm64,universal}
-
-  lipo -create \
-    -o ${out}/Nakama/libnakama/macosx-universal/nakama-sdk.framework/Versions/A/nakama-sdk \
-    ${artifacts_dir}/libnakama-Unreal-macosx-*/Nakama/libnakama/*/nakama-sdk.framework/Versions/A/nakama-sdk
-  # delete original artifacts so that combine_unreal doesn't find them
-  rm -rf ${artifacts_dir}/libnakama-Unreal-macosx-!(universal)-*-git.${git_sha}
-  echo '::endgroup::'
-}
-
 prep_osx_universal() {
   echo '::group::Prepare generic OSX universal binaries'
   local out=${artifacts_dir}/libnakama-macosx-universal-git.${git_sha}
@@ -48,17 +28,6 @@ prep_osx_universal() {
     ${artifacts_dir}/libnakama-macosx-*/*/nakama-sdk.framework/Versions/A/nakama-sdk
 
   rm -rf ${artifacts_dir}/libnakama-macosx-!(universal)-*-git.${git_sha}
-  echo '::endgroup::'
-}
-
-combine_unreal() {
-  echo '::group::Combine Unreal'
-  local out=libnakama-Unreal-git.${git_sha}
-  mkdir -p ${out}
-  cp -rf ${artifacts_dir}/libnakama-Unreal-*/* ${out}/
-  rm -rf ${artifacts_dir}/libnakama-Unreal-*-git.${git_sha}
-  echo "::set-output name=unreal-artifact-name::${out}"
-  echo "::set-output name=unreal-artifact-dir::${out}"
   echo '::endgroup::'
 }
 
@@ -83,8 +52,6 @@ post_run_checks() {
 }
 
 find_git_sha
-prep_unreal_osx_universal
 prep_osx_universal
-combine_unreal
 combine_generic
 post_run_checks


### PR DESCRIPTION
Allows us to build each platform independently if we so choose, either to hand off a particular build to a client or also to debug CI issues for a specific platform, instead of needing to build all the platforms each time.

Also, removes unreal-specific CI stuff in here. That will be moved to nakama-unreal and needs a rework anyway.