### PR TITLE
fix another preset name

### DIFF
--- a/test/CMakePresets.json
+++ b/test/CMakePresets.json
@@ -267,7 +267,7 @@
             "installDir": "out/android-x64"
         },
         {
-            "name": "android-armeabi-v7a-host_osx_arm64",
+            "name": "android-armeabi-v7a-host_linux-x64",
             "inherits": [
                 "android-default"
             ],


### PR DESCRIPTION
It was a duplicate name, intended to refer to linux not osx.