### PR TITLE
exclude libs all tweak

### DIFF
--- a/cmake/linkerFlagsTargets.cmake
+++ b/cmake/linkerFlagsTargets.cmake
@@ -4,5 +4,5 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
     # like when we link libc++ statically or openssl
     # NOTE: target specifically nakama-sdk (our library), because we DONT want it to be set on
     #       nakama-test (test executable) in some cases (namely when linking libc++ statically)
-    target_link_options(nakama-sdk PRIVATE -Wl,--exclude-libs,ALL)
+    target_link_options(nakama-sdk PRIVATE -Wl,--exclude-libs ALL)
 endif()


### PR DESCRIPTION
Some linkers interpret this linker option with a comma properly, but other proprietary linkers appear not to.