### PR TITLE
Further automate test suite running and release 2.7.2

### DIFF
--- a/.github/actions/build-test-and-run/action.yml
+++ b/.github/actions/build-test-and-run/action.yml
@@ -20,12 +20,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Start docker containers for nakama-client-testrunner
+      run: |
+        docker-compose up -d
+      working-directory: nakama-client-testrunner
+      shell: bash
     - id: build
       run: |
         cmake --preset ${{ inputs.preset }}
-        cmake --build ./build/${{ inputs.preset }} --config ${{ inputs.build-type }} -- ${{ inputs.native-tool-options }}
-        cmake --install ./build/${{ inputs.preset }} --config ${{ inputs.build-type }}
-      working-directory: ${{ inputs.nakama-cpp-path }}/test
+        cmake --build ./build/${{ inputs.preset }} --config ${{ inputs.build-type }} -- ${{ inputs.native-tool-options }} --target install run
       shell: bash
     - name: Checkout nakama-client-testrunner
       uses: actions/checkout@v2
@@ -33,15 +36,3 @@ runs:
         repository: heroiclabs/nakama-client-testrunner
         token: ${{ inputs.testrunner-pat }}
         path: nakama-client-testrunner
-    - name: Start docker containers for nakama-client-testrunner
-      run: |
-        docker-compose up -d
-      working-directory: nakama-client-testrunner
-      shell: bash
-    - run: |
-        ./${{ inputs.nakama-cpp-path }}/test/out/${{ inputs.preset }}/nakama-test || {
-            echo "Test failed, showing Nakama log for diagnostics";
-            cat /tmp/nakama.log;
-            exit 1;
-        }
-      shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented below.
 
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
+### [2.7.2] - [2023-03-15]
+### Added
+- Added support for listing matches with a query.
+
+### Fixed
+- Fixed encoding issue with some cursors sent to the server.
+- Fixed an exception that could be thrown when the client sent match data over a bad network.
+
+### Changed
+- Improved build automation around test suite.
+
 ### [2.7.1] - [2023-02-23]
 ### Fixed
 - Restore armeabi-v7a Android support.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -195,3 +195,11 @@ install(IMPORTED_RUNTIME_ARTIFACTS nakama-sdk
     LIBRARY DESTINATION ${_TEST_OUT_DIR}
     FRAMEWORK DESTINATION ${_TEST_OUT_DIR}
 )
+
+if (RUN_ON_DESKTOP_INSTALL AND (CMAKE_SYSTEM_NAME MATCHES "Windows" OR CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin"))
+    add_custom_command(
+        TARGET nakama-test
+        POST_BUILD
+        COMMAND $<TARGET_FILE:nakama-test>
+    )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,24 @@ option(REMOTE_NAKAMA_SDK "Use a remote (vcpkg) installation of Nakama" OFF)
 
 if(REMOTE_NAKAMA_SDK)
     list(APPEND VCPKG_MANIFEST_FEATURES "nakama-sdk")
+else()
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -S .. --preset ${PRESET_NAME}
+        RESULT_VARIABLE result
+    )
+
+    if (result)
+        message(FATAL_ERROR "Configuration of nakama-cpp preset ${PRESET_NAME} failed.")
+    endif()
+
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} --build ../build/${PRESET_NAME} --config MinSizeRel --target install
+        RESULT_VARIABLE result
+    )
+
+    if (result)
+        message(FATAL_ERROR "Building and installing nakama-cpp with preset ${PRESET_NAME} failed.")
+    endif()
 endif()
 
 include(FetchContent)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,10 +196,17 @@ install(IMPORTED_RUNTIME_ARTIFACTS nakama-sdk
     FRAMEWORK DESTINATION ${_TEST_OUT_DIR}
 )
 
-if (RUN_ON_DESKTOP_INSTALL AND (CMAKE_SYSTEM_NAME MATCHES "Windows" OR CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin"))
-    add_custom_command(
-        TARGET nakama-test
-        POST_BUILD
-        COMMAND $<TARGET_FILE:nakama-test>
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows" OR CMAKE_SYSTEM_NAME MATCHES "Linux")
+    add_custom_target(run
+        COMMAND ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/nakama-test
+        DEPENDS install
+        USES_TERMINAL
+    )
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    add_custom_target(run
+        COMMAND $<TARGET_BUNDLE_DIR:nakama-test>/Contents/MacOS/nakama-test
+        DEPENDS install
+        USES_TERMINAL
     )
 endif()

--- a/test/CMakePresets.json
+++ b/test/CMakePresets.json
@@ -17,7 +17,8 @@
                 "RAPIDJSON_BUILD_TESTS": "OFF",
                 "RAPIDJSON_BUILD_THIRDPARTY_GTEST": "OFF",
                 "BUILD_SHARED_LIBS": "ON",
-                "PRESET_NAME": "${presetName}"
+                "PRESET_NAME": "${presetName}",
+                "RUN_ON_DESKTOP_INSTALL": "ON"
             }
         },
         {

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,4 @@
-This is a project for running tests on nakama-cpp via CMake. You'll need an architecture-specific `nakama-sdk` release
-installed in `out`. Make sure it was built with `--config MinSizeRel`.
+This is a project for running tests on nakama-cpp via CMake. Building it will automatically build nakama-sdk for the target platform as well. You can set `-DREMOTE_NAKAMA_SDK=TRUE` when configuring the tests to pull in a version of the nakama-sdk published on vcpkg.
 
 If you are building for Mac/iOS, you'll need to set your NAKAMA_TEST_DEVELOPMENT_TEAM environment variable to your team ID. Your can find your team ID at developer.apple.com.
 
@@ -12,7 +11,6 @@ cmake --build build/<build-preset> --target install
 ```
 
 To build and deploy for iOS, you will need to pass `-- -allowProvisioningUpdates` to the end of your cmake build command.
-
 
 To build for Android, inside the `android` folder:
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,6 @@
 This is a project for running tests on nakama-cpp via CMake. Configuring tests will automatically build (with cache awareness) the nakama-sdk for the target platform as well. Tests will automatically run on desktops after building.
 
 You can set `-DREMOTE_NAKAMA_SDK=ON` when configuring the tests to pull in a version of the nakama-sdk published on vcpkg.
-You can set `-DRUN_ON_DESKTOP_INSTALL=OFF` to disable automatic running of the tests on installation.
 
 If you are building for Mac/iOS, you'll need to set your NAKAMA_TEST_DEVELOPMENT_TEAM environment variable to your team ID. Your can find your team ID at developer.apple.com.
 
@@ -10,11 +9,8 @@ In-tree example:
 cd example
 cmake --list-presets
 cmake --preset <configure-preset>
-cmake --build build/<build-preset>
+cmake --build build/<build-preset> --target install run
 ```
-
-You may optionally append `--target install` to the build command for a properly packaged executable. This is particularly useful
-if you deploying to a mobile or console platform.
 
 To build and deploy for iOS, you will need to pass `-- -allowProvisioningUpdates` to the end of your cmake build command.
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,7 @@
-This is a project for running tests on nakama-cpp via CMake. Building it will automatically build nakama-sdk for the target platform as well. You can set `-DREMOTE_NAKAMA_SDK=TRUE` when configuring the tests to pull in a version of the nakama-sdk published on vcpkg.
+This is a project for running tests on nakama-cpp via CMake. Configuring tests will automatically build (with cache awareness) the nakama-sdk for the target platform as well. Tests will automatically run on desktops after building.
+
+You can set `-DREMOTE_NAKAMA_SDK=ON` when configuring the tests to pull in a version of the nakama-sdk published on vcpkg.
+You can set `-DRUN_ON_DESKTOP_INSTALL=OFF` to disable automatic running of the tests on installation.
 
 If you are building for Mac/iOS, you'll need to set your NAKAMA_TEST_DEVELOPMENT_TEAM environment variable to your team ID. Your can find your team ID at developer.apple.com.
 
@@ -7,8 +10,11 @@ In-tree example:
 cd example
 cmake --list-presets
 cmake --preset <configure-preset>
-cmake --build build/<build-preset> --target install
+cmake --build build/<build-preset>
 ```
+
+You may optionally append `--target install` to the build command for a properly packaged executable. This is particularly useful
+if you deploying to a mobile or console platform.
 
 To build and deploy for iOS, you will need to pass `-- -allowProvisioningUpdates` to the end of your cmake build command.
 

--- a/version.cmake
+++ b/version.cmake
@@ -1,5 +1,5 @@
 # Easy to update by CI scripts file containing our version as well as
 # dependent git repos to achieve reproducible builds
 
-set(LIBNAKAMA_VERSION 2.7.1)
-set(LIBNAKAMA_SOVERSION 2.7.1)
+set(LIBNAKAMA_VERSION 2.7.2)
+set(LIBNAKAMA_SOVERSION 2.7.2)


### PR DESCRIPTION
- automatically build nakama-cpp when nakama-test is built
- automatically run nakama-test when specifying `--target install run`
- changelog