### PR TITLE
run linux ci on ubuntu 20.04 

### DIFF
--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -15,11 +15,6 @@ runs:
           ninja --version 2>/dev/null
         }
 
-        install_gcc_11() {
-          sudo eatmydata add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-          sudo eatmydata apt update && sudo apt install --no-install-recommends -y g++-11 python3-distutils git pkg-config curl zip unzip tar make
-        }
-
         # vcpkg wants mono, make sure it finds one
         # see: https://github.com/microsoft/vcpkg/issues/25585
         ensure_mono() {
@@ -31,10 +26,7 @@ runs:
           mono --version >/dev/null
         }
 
-        (( $(gcc -dumpversion) >= 11 )) || install_gcc_11
         ninja --version 2>/dev/null || install_ninja
         ensure_mono
-        echo 'CC=/usr/bin/gcc-11' >> "$GITHUB_ENV"
-        echo 'CXX=/usr/bin/g++-11' >> "$GITHUB_ENV"
       shell: bash
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         build-type: [MinSizeRel]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         build-type: [MinSizeRel]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We want to use a lower version of GCC so that we can remain compatible with older linux OS's.