### PR TITLE
refactor and fix std::promise usage in `RtClient`

### DIFF
--- a/core/core-rt/NRtClient.cpp
+++ b/core/core-rt/NRtClient.cpp
@@ -124,13 +124,6 @@ std::future<void> NRtClient::connectAsync(NSessionPtr session, bool createStatus
     // stomp the old promise
     _connectPromise = std::make_unique<std::promise<void>>();
 
-    // already connected
-    if (_transport->isConnected()) {
-
-        _connectPromise->set_value();
-        return _connectPromise->get_future();
-    }
-
     connect(session, createStatus, protocol);
 
     return _connectPromise->get_future();

--- a/core/core-rt/NRtClient.cpp
+++ b/core/core-rt/NRtClient.cpp
@@ -246,11 +246,16 @@ void NRtClient::onTransportError(const std::string& description)
         _listener->onError(error);
     }
 
-    bool futureCompleted = _connectPromise->get_future().wait_for(std::chrono::seconds(0)) == std::future_status::ready;
-    if (!futureCompleted)
+    try
     {
         _connectPromise->set_exception(std::make_exception_ptr<NRtException>(NRtException(NRtError(RtErrorCode::CONNECT_ERROR, "An error occurred while connecting."))));
     }
+    catch
+    {
+        // expected to throw an exception if we are already completed. no way to check if std::future is completed, it cannot be double-retrieved with get_future().
+    }
+
+
 }
 
 void NRtClient::onTransportMessage(const NBytes & data)

--- a/impl/wsWslay/NWebsocketWslay.cpp
+++ b/impl/wsWslay/NWebsocketWslay.cpp
@@ -337,6 +337,7 @@ namespace Nakama {
             NLOG(NLogLevel::Debug, "Wslay result: ERROR %s", errMessage.c_str());
             _state = State::Disconnected;
             this->_io->close();
+            _ctx.reset(nullptr);
             fireOnError(errMessage);
             return;
         }

--- a/test/src/realtime/test_lifecycle.cpp
+++ b/test/src/realtime/test_lifecycle.cpp
@@ -170,5 +170,15 @@ namespace Nakama {
 
             test.stopTest(connected);
         }
+
+        void test_connectivity_loss()
+        {
+            bool threadedTick = true;
+            NTest test(__func__, threadedTick);
+            test.setTestTimeoutMs(60 * 1000);
+            test.runTest();
+            NSessionPtr session = test.client->authenticateDeviceAsync("mytestdevice0001", opt::nullopt, opt::nullopt, {}).get();
+            test.rtClient->connect(session, true);
+        }
     }
 }

--- a/test/src/realtime/test_realtime.cpp
+++ b/test/src/realtime/test_realtime.cpp
@@ -37,6 +37,7 @@ void test_rt_reconnect();
 void test_rt_connect_callback();
 void test_rt_double_connect();
 void test_rt_double_connect_async();
+void test_connectivity_loss();
 
 void run_realtime_tests()
 {
@@ -57,6 +58,9 @@ void test_realtime()
     test_rt_connect_callback();
     test_rt_double_connect();
     test_rt_double_connect_async();
+
+    // optional "test". run websocket for a full minute. useful for testing connection loss with network link conditioner.
+    // test_connectivity_loss();
 
     /// change to 10 iterations to trigger https://github.com/microsoft/libHttpClient/issues/698 bug
     for (int i = 0; i < 1; i++) {


### PR DESCRIPTION
- Use nullptr to signal whether or not a connection was made through connectAsync()
- Catch `std::future_error` when setting an exception ptr on the promise object.
- Make sure `_ctx` is properly reset inside the wslay adapter on error.