### PR TITLE
always link against CURL even with BUILD_CURL_SYSTEM defined.

### DIFF
--- a/impl/httpCurl/CMakeLists.txt
+++ b/impl/httpCurl/CMakeLists.txt
@@ -9,14 +9,11 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_library(nakama-impl-http-libcurl OBJECT ${srcs})
 
-if (NOT BUILD_CURL_HTTP_SYSTEM)
-    find_package(CURL CONFIG REQUIRED)
+find_package(CURL CONFIG REQUIRED)
 
-    target_link_libraries(nakama-impl-http-libcurl
-        PUBLIC CURL::libcurl
-    )
-endif()
-
+target_link_libraries(nakama-impl-http-libcurl
+    PUBLIC CURL::libcurl
+)
 
 target_link_libraries(nakama-impl-http-libcurl
     PUBLIC nakama-api-proto nakama::sdk-interface

--- a/impl/wsWslay/CMakeLists.txt
+++ b/impl/wsWslay/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(nakama-impl-ws-wslay INTERFACE
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 
-if (BUILD_CURL_IO AND NOT BUILD_CURL_IO_SYSTEM)
+if (BUILD_CURL_IO OR BUILD_CURL_IO_SYSTEM)
     find_package(CURL CONFIG REQUIRED)
     target_link_libraries(nakama-impl-ws-wslay PRIVATE CURL::libcurl)
 endif()


### PR DESCRIPTION
BUILD_CURL_SYSTEM means just use the system curl, but we still want to link against it.