### PR TITLE
Add missing apis and some small fixes

### DIFF
--- a/core/common/BaseClient.cpp
+++ b/core/common/BaseClient.cpp
@@ -165,11 +165,21 @@ std::future<NSessionPtr> BaseClient::authenticateSteamAsync(
   return promise->get_future();
 }
 
-std::future<NSessionPtr> BaseClient::authenticateRefreshAsync(NSessionPtr session) {
+std::future<NSessionPtr> BaseClient::authenticateRefreshAsync(NSessionPtr session, const NStringMap& vars) {
   auto promise = std::make_shared<std::promise<NSessionPtr>>();
 
   authenticateRefresh(
-      session, [=](NSessionPtr session) { promise->set_value(session); },
+      session, vars, [=](NSessionPtr session) { promise->set_value(session); },
+      [=](const NError& error) { promise->set_exception(std::make_exception_ptr<NException>(error)); });
+
+  return promise->get_future();
+}
+
+std::future<void> BaseClient::sessionLogoutAsync(NSessionPtr session) {
+  auto promise = std::make_shared<std::promise<void>>();
+
+  sessionLogout(
+      session, [=]() { promise->set_value(); },
       [=](const NError& error) { promise->set_exception(std::make_exception_ptr<NException>(error)); });
 
   return promise->get_future();
@@ -372,6 +382,16 @@ std::future<NAccount> BaseClient::getAccountAsync(NSessionPtr session) {
 
   getAccount(
       session, [=](const NAccount& account) { promise->set_value(account); },
+      [=](const NError& error) { promise->set_exception(std::make_exception_ptr<NException>(error)); });
+
+  return promise->get_future();
+}
+
+std::future<void> BaseClient::deleteAccountAsync(NSessionPtr session) {
+  auto promise = std::make_shared<std::promise<void>>();
+
+  deleteAccount(
+      session, [=]() { promise->set_value(); },
       [=](const NError& error) { promise->set_exception(std::make_exception_ptr<NException>(error)); });
 
   return promise->get_future();

--- a/core/common/BaseClient.h
+++ b/core/common/BaseClient.h
@@ -92,7 +92,9 @@ public:
       bool create = false,
       const NStringMap& vars = {}) override;
 
-  std::future<NSessionPtr> authenticateRefreshAsync(NSessionPtr session) override;
+  std::future<NSessionPtr> authenticateRefreshAsync(NSessionPtr session, const NStringMap& vars = {}) override;
+
+  std::future<void> sessionLogoutAsync(NSessionPtr session) override;
 
   std::future<void> linkFacebookAsync(
       NSessionPtr session,
@@ -150,6 +152,8 @@ public:
       const opt::optional<bool>& reset = opt::nullopt) override;
 
   std::future<NAccount> getAccountAsync(NSessionPtr session) override;
+
+  std::future<void> deleteAccountAsync(NSessionPtr session) override;
 
   std::future<void> updateAccountAsync(
       NSessionPtr session,

--- a/core/core-rest/RestClient.cpp
+++ b/core/core-rest/RestClient.cpp
@@ -1198,8 +1198,8 @@ void RestClient::deleteAccount(
   try {
     NLOG_INFO("...");
 
-    auto accoutData(make_shared<nakama::api::Account>());
-    RestReqContext* ctx = createReqContext(accoutData.get());
+    auto accountData(make_shared<nakama::api::Account>());
+    RestReqContext* ctx = createReqContext(accountData.get());
     setSessionAuth(ctx, session);
 
     ctx->successCallback = successCallback;

--- a/core/core-rest/RestClient.h
+++ b/core/core-rest/RestClient.h
@@ -115,8 +115,11 @@ public:
 
   void authenticateRefresh(
       NSessionPtr session,
-      std::function<void(NSessionPtr)> successCallback = nullptr,
-      ErrorCallback errorCallback = nullptr) override;
+      const NStringMap& vars,
+      std::function<void(NSessionPtr)> successCallback,
+      ErrorCallback errorCallback) override;
+
+  void sessionLogout(NSessionPtr session, std::function<void()> successCallback, ErrorCallback errorCallback) override;
 
   void linkFacebook(
       NSessionPtr session,
@@ -236,8 +239,10 @@ public:
 
   void getAccount(
       NSessionPtr session,
-      std::function<void(const NAccount&)> successCallback = nullptr,
-      ErrorCallback errorCallback = nullptr) override;
+      std::function<void(const NAccount&)> successCallback,
+      ErrorCallback errorCallback) override;
+
+  void deleteAccount(NSessionPtr session, std::function<void()> successCallback, ErrorCallback errorCallback) override;
 
   void updateAccount(
       NSessionPtr session,

--- a/impl/httpCurl/NHttpClientLibCurl.cpp
+++ b/impl/httpCurl/NHttpClientLibCurl.cpp
@@ -109,8 +109,9 @@ void NHttpClientLibCurl::request(const NHttpRequest& req, const NHttpResponseCal
     return;
   }
 
-  if (_timeout >= 0) {
-    curl_code = curl_easy_setopt(curl_easy.get(), CURLOPT_TIMEOUT, _timeout);
+  if (_timeout >= std::chrono::milliseconds(0)) {
+    curl_code = curl_easy_setopt(
+        curl_easy.get(), CURLOPT_TIMEOUT_MS, duration_cast<std::chrono::milliseconds>(_timeout).count());
     if (curl_code != CURLE_OK) {
       handle_curl_easy_set_opt_error("setting timeout", curl_code, callback);
       return;
@@ -199,7 +200,7 @@ void NHttpClientLibCurl::request(const NHttpRequest& req, const NHttpResponseCal
 
 void NHttpClientLibCurl::setBaseUri(const std::string& uri) { _base_uri = uri; }
 
-void NHttpClientLibCurl::setTimeout(int seconds) { _timeout = seconds; }
+void NHttpClientLibCurl::setTimeout(std::chrono::milliseconds timeout) { _timeout = timeout; }
 
 void NHttpClientLibCurl::tick() {
   std::unique_lock lock(_mutex, std::try_to_lock);

--- a/impl/httpCurl/NHttpClientLibCurl.cpp
+++ b/impl/httpCurl/NHttpClientLibCurl.cpp
@@ -16,29 +16,29 @@ static int debug_callback(CURL* handle, curl_infotype type, char* data, size_t s
   (void)userp;
 
   switch (type) {
-  case CURLINFO_TEXT:
-    NLOG(Nakama::NLogLevel::Debug, "libcurl debug info <=> Text: %s", data);
-  default: /* in case a new one is introduced */
-    return 0;
+    case CURLINFO_TEXT:
+      NLOG(Nakama::NLogLevel::Debug, "libcurl debug info <=> Text: %s", data);
+    default: /* in case a new one is introduced */
+      return 0;
 
-  case CURLINFO_HEADER_OUT:
-    text = "=> Send header";
-    break;
-  case CURLINFO_DATA_OUT:
-    text = "=> Send data";
-    break;
-  case CURLINFO_SSL_DATA_OUT:
-    text = "=> Send SSL data";
-    break;
-  case CURLINFO_HEADER_IN:
-    text = "<= Recv header";
-    break;
-  case CURLINFO_DATA_IN:
-    text = "<= Recv data";
-    break;
-  case CURLINFO_SSL_DATA_IN:
-    text = "<= Recv SSL data";
-    break;
+    case CURLINFO_HEADER_OUT:
+      text = "=> Send header";
+      break;
+    case CURLINFO_DATA_OUT:
+      text = "=> Send data";
+      break;
+    case CURLINFO_SSL_DATA_OUT:
+      text = "=> Send SSL data";
+      break;
+    case CURLINFO_HEADER_IN:
+      text = "<= Recv header";
+      break;
+    case CURLINFO_DATA_IN:
+      text = "<= Recv data";
+      break;
+    case CURLINFO_SSL_DATA_IN:
+      text = "<= Recv SSL data";
+      break;
   }
 
   NLOG(Nakama::NLogLevel::Debug, "libcurl debug info: %s", text);
@@ -81,26 +81,26 @@ void NHttpClientLibCurl::request(const NHttpRequest& req, const NHttpResponseCal
 
   const char* callMethod = nullptr;
   switch (req.method) {
-  case NHttpReqMethod::POST:
-    callMethod = "POST";
-    // manually set content-length if there's no body.
-    if (req.body.empty()) {
-      headers_list = curl_slist_append(headers_list, "Content-Length: 0");
-      if (headers_list == NULL) {
-        NLOG(Nakama::NLogLevel::Error, "error writing header: Content-Length");
-        return;
+    case NHttpReqMethod::POST:
+      callMethod = "POST";
+      // manually set content-length if there's no body.
+      if (req.body.empty()) {
+        headers_list = curl_slist_append(headers_list, "Content-Length: 0");
+        if (headers_list == NULL) {
+          NLOG(Nakama::NLogLevel::Error, "error writing header: Content-Length");
+          return;
+        }
       }
-    }
-    break;
-  case NHttpReqMethod::GET:
-    callMethod = "GET";
-    break;
-  case NHttpReqMethod::PUT:
-    callMethod = "PUT";
-    break;
-  case NHttpReqMethod::DEL:
-    callMethod = "DELETE";
-    break;
+      break;
+    case NHttpReqMethod::GET:
+      callMethod = "GET";
+      break;
+    case NHttpReqMethod::PUT:
+      callMethod = "PUT";
+      break;
+    case NHttpReqMethod::DEL:
+      callMethod = "DELETE";
+      break;
   }
 
   CURLcode curl_code = curl_easy_setopt(curl_easy.get(), CURLOPT_URL, uri.c_str());
@@ -267,8 +267,9 @@ void NHttpClientLibCurl::tick() {
           response->statusCode = static_cast<int>(response_code);
 
           if (curl_code != CURLE_OK) {
-            NLOG(Nakama::NLogLevel::Error, "curl_easy_getinfo() failed when getting response code, code %d.\n",
-                 (int)curl_code);
+            NLOG(
+                Nakama::NLogLevel::Error, "curl_easy_getinfo() failed when getting response code, code %d.\n",
+                (int)curl_code);
           }
         }
 
@@ -303,8 +304,10 @@ void NHttpClientLibCurl::cancelAllRequests() {
   _contexts.clear();
 }
 
-void NHttpClientLibCurl::handle_curl_easy_set_opt_error(std::string action, CURLcode code,
-                                                        const NHttpResponseCallback& callback) {
+void NHttpClientLibCurl::handle_curl_easy_set_opt_error(
+    std::string action,
+    CURLcode code,
+    const NHttpResponseCallback& callback) {
   auto response = std::shared_ptr<NHttpResponse>(new NHttpResponse());
   response->errorMessage =
       "curl_easy_getinfo() error while : " + action + ", code: " + std::string(curl_easy_strerror(code));

--- a/impl/wsWslay/WslayIOCurl.h
+++ b/impl/wsWslay/WslayIOCurl.h
@@ -47,10 +47,10 @@ public:
 
 #if __ANDROID__
     CACertificateData* data = Nakama::getCaCertificates();
-    if (data == NULL) {
+    if (data == nullptr) {
       // Has System.loadLibrary("nakama-sdk") been called?
       NLOG(Nakama::NLogLevel::Error, "libcurl error: could not access CA Certificates.");
-      return;
+      return NetIOAsyncResult::ERR;
     } else {
       struct curl_blob blob;
       blob.data = reinterpret_cast<char*>(data->data);

--- a/impl/wsWslay/WslayIOCurl.h
+++ b/impl/wsWslay/WslayIOCurl.h
@@ -47,11 +47,17 @@ public:
 
 #if __ANDROID__
     CACertificateData* data = Nakama::getCaCertificates();
-    struct curl_blob blob;
-    blob.data = reinterpret_cast<char*>(data->data);
-    blob.len = data->len;
-    blob.flags = CURL_BLOB_COPY;
-    curl_easy_setopt(_curl.get(), CURLOPT_CAINFO_BLOB, &blob);
+    if (data == NULL) {
+      // Has System.loadLibrary("nakama-sdk") been called?
+      NLOG(Nakama::NLogLevel::Error, "libcurl error: could not access CA Certificates.");
+      return;
+    } else {
+      struct curl_blob blob;
+      blob.data = reinterpret_cast<char*>(data->data);
+      blob.len = data->len;
+      blob.flags = CURL_BLOB_COPY;
+      curl_easy_setopt(_curl.get(), CURLOPT_CAINFO_BLOB, &blob);
+    }
 #endif
 
     // only way to do async connect is via curl_multi interface

--- a/interface/include/nakama-cpp/NClientInterface.h
+++ b/interface/include/nakama-cpp/NClientInterface.h
@@ -258,7 +258,17 @@ public:
    **/
   virtual void authenticateRefresh(
       NSessionPtr session,
+      const NStringMap& vars = {},
       std::function<void(NSessionPtr)> successCallback = nullptr,
+      ErrorCallback errorCallback = nullptr) = 0;
+
+  /**
+   * Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
+   * @param session The session of the user to log out.
+   **/
+  virtual void sessionLogout(
+      NSessionPtr session,
+      std::function<void()> successCallback = nullptr,
       ErrorCallback errorCallback = nullptr) = 0;
 
   /**
@@ -504,6 +514,16 @@ public:
   virtual void getAccount(
       NSessionPtr session,
       std::function<void(const NAccount&)> successCallback = nullptr,
+      ErrorCallback errorCallback = nullptr) = 0;
+
+  /**
+   * Delete the user account owned by the session.
+   *
+   * @param session The session of the user.
+   */
+  virtual void deleteAccount(
+      NSessionPtr session,
+      std::function<void()> successCallback = nullptr,
       ErrorCallback errorCallback = nullptr) = 0;
 
   /**
@@ -1251,7 +1271,13 @@ public:
    * Refresh a user's session using a refresh token retrieved from a previous authentication request.
    * @param session The session of the user.
    **/
-  virtual std::future<NSessionPtr> authenticateRefreshAsync(NSessionPtr session) = 0;
+  virtual std::future<NSessionPtr> authenticateRefreshAsync(NSessionPtr session, const NStringMap& vars = {}) = 0;
+
+  /**
+   * Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
+   * @param session The session of the user to log out.
+   **/
+  virtual std::future<void> sessionLogoutAsync(NSessionPtr session) = 0;
 
   /**
    * Link a Facebook profile to a user account.
@@ -1434,6 +1460,13 @@ public:
    * @param session The session of the user.
    */
   virtual std::future<NAccount> getAccountAsync(NSessionPtr session) = 0;
+
+  /**
+   * Delete the user account owned by the session.
+   *
+   * @param session The session of the user.
+   */
+  virtual std::future<void> deleteAccountAsync(NSessionPtr session) = 0;
 
   /**
    * Update the current user's account on the server.

--- a/satori-cpp/src/InternalLowLevelSatoriAPI.cpp
+++ b/satori-cpp/src/InternalLowLevelSatoriAPI.cpp
@@ -79,10 +79,11 @@ bool jsonValueToSEvent(const rapidjson::Value& input, SEvent& output) {
 bool SInternalEvent::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSEvent(d, *this);
@@ -109,10 +110,11 @@ bool jsonValueToSExperiment(const rapidjson::Value& input, SExperiment& output) 
 bool SInternalExperiment::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SExperiment JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SExperiment JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSExperiment(d, *this);
@@ -121,10 +123,11 @@ bool SInternalExperiment::fromJson(std::string jsonString) {
 bool SInternalExperimentList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SExperimentList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) +
-                                  ": " + std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " +
-                                  jsonString + " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SExperimentList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
 
@@ -199,10 +202,11 @@ bool jsonValueToSFlag(const rapidjson::Value& input, SFlag& output) {
 bool SInternalFlag::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SFlag JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SFlag JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSFlag(d, *this);
@@ -211,10 +215,11 @@ bool SInternalFlag::fromJson(std::string jsonString) {
 bool SInternalFlagList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SFlagList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SFlagList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("flags")) {
@@ -281,10 +286,11 @@ bool jsonValueToSFlagOverride(const rapidjson::Value& input, SFlagOverride& outp
 bool SInternalFlagOverride::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SFlagOverride JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SFlagOverride JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSFlagOverride(d, *this);
@@ -293,10 +299,11 @@ bool SInternalFlagOverride::fromJson(std::string jsonString) {
 bool SInternalFlagOverrideList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SFlagOverrideList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) +
-                                  ": " + std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " +
-                                  jsonString + " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SFlagOverrideList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("flags")) {
@@ -390,10 +397,11 @@ bool jsonValueToSLiveEvent(const rapidjson::Value& input, SLiveEvent& output) {
 bool SInternalLiveEvent::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SLiveEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SLiveEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSLiveEvent(d, *this);
@@ -402,10 +410,11 @@ bool SInternalLiveEvent::fromJson(std::string jsonString) {
 bool SInternalLiveEventList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SLiveEventList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) +
-                                  ": " + std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " +
-                                  jsonString + " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SLiveEventList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
 
@@ -440,10 +449,11 @@ bool jsonValueToSProperties(const rapidjson::Value& input, SProperties& output) 
 bool SInternalProperties::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SProperties JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SProperties JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSProperties(d, *this);
@@ -452,10 +462,11 @@ bool SInternalProperties::fromJson(std::string jsonString) {
 bool SInternalSession::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SSession JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SSession JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("token")) {
@@ -567,10 +578,11 @@ bool jsonValueToSMessage(const rapidjson::Value& input, SMessage& output) {
 bool SInternalMessage::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError("Parse SMessage JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
-                                  " >>.",
-                              Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SMessage JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSMessage(d, *this);
@@ -579,10 +591,11 @@ bool SInternalMessage::fromJson(std::string jsonString) {
 bool SInternalGetMessageListResponse::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(Nakama::NError(
-        "Parse SGetMessageListResponse JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-            std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-        Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(
+        Nakama::NError(
+            "Parse SGetMessageListResponse JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+            Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("messages")) {

--- a/satori-cpp/src/InternalLowLevelSatoriAPI.cpp
+++ b/satori-cpp/src/InternalLowLevelSatoriAPI.cpp
@@ -79,11 +79,10 @@ bool jsonValueToSEvent(const rapidjson::Value& input, SEvent& output) {
 bool SInternalEvent::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSEvent(d, *this);
@@ -110,11 +109,10 @@ bool jsonValueToSExperiment(const rapidjson::Value& input, SExperiment& output) 
 bool SInternalExperiment::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SExperiment JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SExperiment JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSExperiment(d, *this);
@@ -123,11 +121,10 @@ bool SInternalExperiment::fromJson(std::string jsonString) {
 bool SInternalExperimentList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SExperimentList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SExperimentList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) +
+                                  ": " + std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " +
+                                  jsonString + " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
 
@@ -202,11 +199,10 @@ bool jsonValueToSFlag(const rapidjson::Value& input, SFlag& output) {
 bool SInternalFlag::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SFlag JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SFlag JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSFlag(d, *this);
@@ -215,11 +211,10 @@ bool SInternalFlag::fromJson(std::string jsonString) {
 bool SInternalFlagList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SFlagList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SFlagList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("flags")) {
@@ -286,11 +281,10 @@ bool jsonValueToSFlagOverride(const rapidjson::Value& input, SFlagOverride& outp
 bool SInternalFlagOverride::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SFlagOverride JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SFlagOverride JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSFlagOverride(d, *this);
@@ -299,11 +293,10 @@ bool SInternalFlagOverride::fromJson(std::string jsonString) {
 bool SInternalFlagOverrideList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SFlagOverrideList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SFlagOverrideList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) +
+                                  ": " + std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " +
+                                  jsonString + " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("flags")) {
@@ -397,11 +390,10 @@ bool jsonValueToSLiveEvent(const rapidjson::Value& input, SLiveEvent& output) {
 bool SInternalLiveEvent::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SLiveEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SLiveEvent JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSLiveEvent(d, *this);
@@ -410,11 +402,10 @@ bool SInternalLiveEvent::fromJson(std::string jsonString) {
 bool SInternalLiveEventList::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SLiveEventList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SLiveEventList JSON failed. Error at " + std::to_string(d.GetErrorOffset()) +
+                                  ": " + std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " +
+                                  jsonString + " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
 
@@ -449,11 +440,10 @@ bool jsonValueToSProperties(const rapidjson::Value& input, SProperties& output) 
 bool SInternalProperties::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SProperties JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SProperties JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSProperties(d, *this);
@@ -462,11 +452,10 @@ bool SInternalProperties::fromJson(std::string jsonString) {
 bool SInternalSession::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SSession JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SSession JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("token")) {
@@ -496,37 +485,57 @@ bool jsonValueToSMessage(const rapidjson::Value& input, SMessage& output) {
     output.schedule_id = input["schedule_id"].GetString();
   }
   if (input.HasMember("send_time")) {
-    if (!input["send_time"].IsInt64()) {
+    if (!input["send_time"].IsString()) {
       return false;
     }
-    output.send_time = input["send_time"].GetInt64();
+    std::string time_string = input["send_time"].GetString();
+    size_t string_length = input["send_time"].GetStringLength();
+    output.send_time = std::stoull(time_string, &string_length);
+  } else {
+    output.send_time = 0;
   }
   if (input.HasMember("metadata") && !jsonValueToStringMap(input["metadata"], output.metadata)) {
     return false;
   }
   if (input.HasMember("create_time")) {
-    if (!input["create_time"].IsInt64()) {
+    if (!input["create_time"].IsString()) {
       return false;
     }
-    output.create_time = input["create_time"].GetInt64();
+    std::string time_string = input["create_time"].GetString();
+    size_t string_length = input["create_time"].GetStringLength();
+    output.create_time = std::stoull(time_string, &string_length);
+  } else {
+    output.create_time = 0;
   }
   if (input.HasMember("update_time")) {
-    if (!input["update_time"].IsInt64()) {
+    if (!input["update_time"].IsString()) {
       return false;
     }
-    output.update_time = input["update_time"].GetInt64();
+    std::string time_string = input["update_time"].GetString();
+    size_t string_length = input["update_time"].GetStringLength();
+    output.update_time = std::stoull(time_string, &string_length);
+  } else {
+    output.update_time = 0;
   }
   if (input.HasMember("read_time")) {
-    if (!input["read_time"].IsInt64()) {
+    if (!input["read_time"].IsString()) {
       return false;
     }
-    output.read_time = input["read_time"].GetInt64();
+    std::string time_string = input["read_time"].GetString();
+    size_t string_length = input["read_time"].GetStringLength();
+    output.read_time = std::stoull(time_string, &string_length);
+  } else {
+    output.read_time = 0;
   }
   if (input.HasMember("consume_time")) {
-    if (!input["consume_time"].IsInt64()) {
+    if (!input["consume_time"].IsString()) {
       return false;
     }
-    output.consume_time = input["consume_time"].GetInt64();
+    std::string time_string = input["consume_time"].GetString();
+    size_t string_length = input["consume_time"].GetStringLength();
+    output.consume_time = std::stoull(time_string, &string_length);
+  } else {
+    output.consume_time = 0;
   }
   if (input.HasMember("text")) {
     if (!input["text"].IsString()) {
@@ -558,11 +567,10 @@ bool jsonValueToSMessage(const rapidjson::Value& input, SMessage& output) {
 bool SInternalMessage::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SMessage JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError("Parse SMessage JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+                                  std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString +
+                                  " >>.",
+                              Nakama::ErrorCode::InternalError));
     return false;
   }
   return jsonValueToSMessage(d, *this);
@@ -571,11 +579,10 @@ bool SInternalMessage::fromJson(std::string jsonString) {
 bool SInternalGetMessageListResponse::fromJson(std::string jsonString) {
   rapidjson::Document d;
   if (d.ParseInsitu(jsonString.data()).HasParseError()) {
-    NLOG_ERROR(
-        Nakama::NError(
-            "Parse SGetMessageListResponse JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
-                std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
-            Nakama::ErrorCode::InternalError));
+    NLOG_ERROR(Nakama::NError(
+        "Parse SGetMessageListResponse JSON failed. Error at " + std::to_string(d.GetErrorOffset()) + ": " +
+            std::string(GetParseError_En(d.GetParseError())) + " HTTP body:<< " + jsonString + " >>.",
+        Nakama::ErrorCode::InternalError));
     return false;
   }
   if (d.HasMember("messages")) {

--- a/satori-cpp/test/main.cpp
+++ b/satori-cpp/test/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     bool done = false;
 
     Nakama::NClientParameters parameters = Nakama::NClientParameters();
-    parameters.serverKey = "a76ae76b-3342-4cbd-9c54-f532c5c1a949";
+    parameters.serverKey = "b76214d3-c2a2-4984-9473-3fbd5c55af8e";
     Satori::SClientPtr client =
         Satori::createRestClient(parameters, Nakama::createDefaultHttpTransport(parameters.platformParams));
 
@@ -70,6 +70,14 @@ int main(int argc, char** argv) {
 
     Satori::SLiveEventList liveEvents = getFromFuture(client->getLiveEventsAsync(session3), client);
     std::cout << "Live events num:" << liveEvents.live_events.size() << std::endl;
+    Satori::SGetMessageListResponse messages =
+        getFromFuture(client->getMessagesAsync(session3, 10, false, std::string()), client);
+    std::cout << "Messages size:" << messages.messages.size() << std::endl;
+    if (!messages.messages.empty()) {
+      getFromFuture(client->updateMessageAsync(session3, messages.messages[0].id, messages.messages[0].send_time + 1000,
+                                               messages.messages[0].send_time + 100),
+                    client);
+    }
   } catch (const std::future_error& e) {
     std::cout << "Caught a future_error with code \"" << e.code() << "\"\nMessage: \"" << e.what() << "\"\n";
   } catch (const std::exception& e) {

--- a/satori-cpp/test/main.cpp
+++ b/satori-cpp/test/main.cpp
@@ -74,9 +74,11 @@ int main(int argc, char** argv) {
         getFromFuture(client->getMessagesAsync(session3, 10, false, std::string()), client);
     std::cout << "Messages size:" << messages.messages.size() << std::endl;
     if (!messages.messages.empty()) {
-      getFromFuture(client->updateMessageAsync(session3, messages.messages[0].id, messages.messages[0].send_time + 1000,
-                                               messages.messages[0].send_time + 100),
-                    client);
+      getFromFuture(
+          client->updateMessageAsync(
+              session3, messages.messages[0].id, messages.messages[0].send_time + 1000,
+              messages.messages[0].send_time + 100),
+          client);
     }
   } catch (const std::future_error& e) {
     std::cout << "Caught a future_error with code \"" << e.code() << "\"\nMessage: \"" << e.what() << "\"\n";

--- a/test/src/test_authentication.cpp
+++ b/test/src/test_authentication.cpp
@@ -86,12 +86,18 @@ void test_authenticateRefresh() {
 
     auto errorCallback2 = [&test](const NError& error) { test.stopTest(error); };
 
-    test.client->authenticateRefresh(session1, successCallback2, errorCallback2);
+    NStringMap vars;
+
+    vars.emplace("param1", "test value changed");
+    vars.emplace("param2", "test value new");
+
+    test.client->authenticateRefresh(session1, vars, successCallback2, errorCallback2);
   };
 
   NStringMap vars;
 
   vars.emplace("param1", "test value");
+  vars.emplace("paramC", "test constant");
 
   test.client->authenticateDevice("mytestdevice0001", opt::nullopt, true, vars, successCallback);
 


### PR DESCRIPTION
- Add default .clang-default for project.
- Add delete account api call.
- Add session logout api call.
- Expand session refresh to include vars (this can break existing code. Just pass an empty map as new vars parameter and that's it "{}")
- Fix Android crash on accessing CACertificates without calling loadLibrary.