### PR TITLE
Use unique user IDs in integration tests to prevent false failures in CI

### DIFF
--- a/integrationtests/src/test_getAccount.cpp
+++ b/integrationtests/src/test_getAccount.cpp
@@ -47,7 +47,7 @@ void test_getAccountAndUpdate() {
     test.client->getAccount(session, successCallback);
   };
 
-  test.client->authenticateDevice("mytestdevice0000", std::nullopt, true, {}, successCallback);
+  test.client->authenticateDevice(TestGuid::newGuid(), std::nullopt, true, {}, successCallback);
 
   test.runTest();
 }

--- a/integrationtests/src/test_restoreSession.cpp
+++ b/integrationtests/src/test_restoreSession.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "NTest.h"
+#include "TestGuid.h"
 #include "globals.h"
 #include "nakama-cpp/NUtils.h"
 
@@ -88,7 +89,7 @@ void test_restoreSession() {
     }
   };
 
-  test.client->authenticateDevice("mytestdevice0000", std::nullopt, true, {}, successCallback);
+  test.client->authenticateDevice(TestGuid::newGuid(), std::nullopt, true, {}, successCallback);
 
   test.runTest();
 }

--- a/integrationtests/src/test_storage.cpp
+++ b/integrationtests/src/test_storage.cpp
@@ -44,7 +44,7 @@ void test_writeStorageInvalidArgument() {
     test.client->writeStorageObjects(session, objects, nullptr, errorCallback);
   };
 
-  test.client->authenticateDevice("mytestdevice0000", std::nullopt, true, {}, successCallback);
+  test.client->authenticateDevice(TestGuid::newGuid(), std::nullopt, true, {}, successCallback);
 
   test.runTest();
 }


### PR DESCRIPTION
For following integration tests:
  test_getAccountAndUpdate
  test_restoreSession
  test_writeStorageInvalidArgument

replaced hardcoded device ID  with unique GUIDs passed to authenticateDevice(). This prevents account state conflict during parallel test execution on Linux. 