### PR TITLE
Add banGroupUsers function (#84)

### DIFF
--- a/core/common/BaseClient.cpp
+++ b/core/common/BaseClient.cpp
@@ -549,6 +549,17 @@ BaseClient::kickGroupUsersAsync(NSessionPtr session, const std::string& groupId,
   return promise->get_future();
 }
 
+std::future<void>
+BaseClient::banGroupUsersAsync(NSessionPtr session, const std::string& groupId, const std::vector<std::string>& ids) {
+  auto promise = std::make_shared<std::promise<void>>();
+
+  banGroupUsers(
+      session, groupId, ids, [=]() { promise->set_value(); },
+      [=](const NError& error) { promise->set_exception(std::make_exception_ptr<NException>(error)); });
+
+  return promise->get_future();
+}
+
 std::future<void> BaseClient::joinGroupAsync(NSessionPtr session, const std::string& groupId) {
   auto promise = std::make_shared<std::promise<void>>();
 

--- a/core/common/BaseClient.h
+++ b/core/common/BaseClient.h
@@ -212,6 +212,9 @@ public:
   std::future<void>
   kickGroupUsersAsync(NSessionPtr session, const std::string& groupId, const std::vector<std::string>& ids) override;
 
+  std::future<void>
+  banGroupUsersAsync(NSessionPtr session, const std::string& groupId, const std::vector<std::string>& ids) override;
+
   std::future<void> joinGroupAsync(NSessionPtr session, const std::string& groupId) override;
 
   std::future<void> leaveGroupAsync(NSessionPtr session, const std::string& groupId) override;

--- a/core/core-rest/RestClient.cpp
+++ b/core/core-rest/RestClient.cpp
@@ -1588,6 +1588,33 @@ void RestClient::kickGroupUsers(
   }
 }
 
+void RestClient::banGroupUsers(
+    NSessionPtr session,
+    const std::string& groupId,
+    const std::vector<std::string>& ids,
+    std::function<void()> successCallback,
+    ErrorCallback errorCallback) {
+  try {
+    NLOG_INFO("...");
+
+    RestReqContext* ctx = createReqContext(nullptr);
+    setSessionAuth(ctx, session);
+
+    ctx->successCallback = successCallback;
+    ctx->errorCallback = errorCallback;
+
+    NHttpQueryArgs args;
+
+    for (auto& id : ids) {
+      args.emplace("user_ids", id);
+    }
+
+    sendReq(ctx, NHttpReqMethod::POST, "/v2/group/" + encodeURIComponent(groupId) + "/ban", "", std::move(args));
+  } catch (exception& e) {
+    NLOG_ERROR("exception: " + string(e.what()));
+  }
+}
+
 void RestClient::joinGroup(
     NSessionPtr session,
     const std::string& groupId,

--- a/core/core-rest/RestClient.cpp
+++ b/core/core-rest/RestClient.cpp
@@ -1595,8 +1595,6 @@ void RestClient::banGroupUsers(
     std::function<void()> successCallback,
     ErrorCallback errorCallback) {
   try {
-    NLOG_INFO("...");
-
     RestReqContext* ctx = createReqContext(nullptr);
     setSessionAuth(ctx, session);
 

--- a/core/core-rest/RestClient.h
+++ b/core/core-rest/RestClient.h
@@ -335,6 +335,13 @@ public:
       std::function<void()> successCallback,
       ErrorCallback errorCallback) override;
 
+ void banGroupUsers(
+    NSessionPtr session,
+    const std::string& groupId,
+    const std::vector<std::string>& ids,
+    std::function<void()> successCallback,
+    ErrorCallback errorCallback) override;
+
   void joinGroup(
       NSessionPtr session,
       const std::string& groupId,

--- a/integrationtests/src/test_groups.cpp
+++ b/integrationtests/src/test_groups.cpp
@@ -252,6 +252,26 @@ void test_addAndKickGroupUser() {
   }
 }
 
+void test_addAndBanGroupUser() {
+  NTest test(__func__, true);
+  test.runTest();
+
+  try {
+    auto session1 = test.client->authenticateCustomAsync(TestGuid::newGuid(), "", true).get();
+    test.addSession(session1);
+    auto session2 = test.client->authenticateCustomAsync(TestGuid::newGuid(), "", true).get();
+    test.addSession(session2);
+    NGroup group =
+        test.client->createGroupAsync(session1, "BanTest-" + TestGuid::newGuid(), "", "", "", true).get();
+    test.client->addGroupUsersAsync(session1, group.id, {session2->getUserId()}).get();
+    test.client->banGroupUsersAsync(session1, group.id, {session2->getUserId()}).get();
+    test.stopTest(true);
+  } catch (const std::exception& e) {
+    NLOG_INFO("test failed: " + std::string(e.what()));
+    test.stopTest(false);
+  }
+}
+
 void test_createClosedGroup() {
   NTest test(__func__, true);
   test.runTest();
@@ -474,6 +494,7 @@ void test_groups() {
   test_deleteGroup();
   test_joinAndLeaveGroup();
   test_addAndKickGroupUser();
+  test_addAndBanGroupUser();
   test_createClosedGroup();
   test_createGroup_withDescription();
   test_updateGroup();

--- a/interface/include/nakama-cpp/NClientInterface.h
+++ b/interface/include/nakama-cpp/NClientInterface.h
@@ -703,6 +703,20 @@ public:
       ErrorCallback errorCallback = nullptr) = 0;
 
   /**
+   * Ban one or more users from the group.
+   *
+   * @param session The session of the user.
+   * @param groupId The id of the group.
+   * @param ids The ids of the users to ban.
+   */
+  virtual void banGroupUsers(
+      NSessionPtr session,
+      const std::string& groupId,
+      const std::vector<std::string>& ids,
+      std::function<void()> successCallback = nullptr,
+      ErrorCallback errorCallback = nullptr) = 0;
+
+  /**
    * Join a group if it has open membership or request to join it.
    *
    * @param session The session of the user.
@@ -1615,6 +1629,9 @@ public:
    */
   virtual std::future<void>
   kickGroupUsersAsync(NSessionPtr session, const std::string& groupId, const std::vector<std::string>& ids) = 0;
+
+  virtual std::future<void> 
+  banGroupUsersAsync(NSessionPtr session, const std::string& groupId, const std::vector<std::string>& ids) = 0;
 
   /**
    * Join a group if it has open membership or request to join it.


### PR DESCRIPTION
Closes #84.

Adds the missing `banGroupUsers` client function, which was present in the other Nakama SDKs (Go, JS, .NET) but absent from the C++ client.

## Implementation
- Uses the existing `kickGroupUsers` pattern across `NClientInterface.h`, `BaseClient` (async wrapper), and `RestClient` (REST implementation).
- POSTs to `/v2/group/{groupId}/ban`, matching the server endpoint and the other SDKs.
- Added an integration test (`test_addAndBanGroupUser`) in `test_groups.cpp`, registered in `test_groups()`, similar to `test_addAndKickGroupUser`.

## Note on gRPC
REST client only for now. I noticed `sessionLogout` is also REST-only, so I followed that since the gRPC version would need a `BanGroupUsersRequest` type and an `AsyncBanGroupUsers` stub, and neither is in the generated API yet. Can extend to gRPC if you want the API definitions regenerated.

## Testing
The change compiles cleanly on Windows (win-x64, MSVC). I haven't run the integration suite locally as it requires a running server, but the test mirrors the existing `kickGroupUsers` coverage and is ready for CI.