### PR TITLE
Add Create Match with Name (#77)

### DIFF
--- a/core/core-rt/NRtClient.cpp
+++ b/core/core-rt/NRtClient.cpp
@@ -490,12 +490,19 @@ void NRtClient::removeChatMessage(
   send(msg);
 }
 
-void NRtClient::createMatch(std::function<void(const NMatch&)> successCallback, RtErrorCallback errorCallback) {
-  NLOG_INFO("...");
-
+void NRtClient::createMatch(
+  const std::optional<std::string>& name,
+  std::function<void(const NMatch&)> successCallback, 
+  RtErrorCallback errorCallback) {
+  
+    NLOG_INFO("...");
+  
   ::nakama::realtime::Envelope msg;
 
-  msg.mutable_match_create();
+  ::nakama::realtime::MatchCreate* matchCreate = msg.mutable_match_create();
+  if (name.has_value()) {
+       matchCreate->set_name(*name);
+   }
 
   std::shared_ptr<RtRequestContext> ctx = createReqContext(msg);
 
@@ -1125,10 +1132,10 @@ std::future<void> NRtClient::removeChatMessageAsync(const std::string& channelId
   return promise->get_future();
 }
 
-std::future<NMatch> NRtClient::createMatchAsync() {
+std::future<NMatch> NRtClient::createMatchAsync(const std::optional<std::string>& name) {
   auto promise = std::make_shared<std::promise<NMatch>>();
 
-  createMatch(
+  createMatch( name,
       [=](const NMatch& match) { promise->set_value(match); },
       [=](const NRtError& error) { promise->set_exception(std::make_exception_ptr<NRtException>(error)); });
 

--- a/core/core-rt/NRtClient.h
+++ b/core/core-rt/NRtClient.h
@@ -92,8 +92,10 @@ public:
       std::function<void(const NChannelMessageAck&)> successCallback = nullptr,
       RtErrorCallback errorCallback = nullptr) override;
 
-  void
-  createMatch(std::function<void(const NMatch&)> successCallback, RtErrorCallback errorCallback = nullptr) override;
+  void createMatch( 
+    const std::optional<std::string>& name = std::nullopt,
+    std::function<void(const NMatch&)> successCallback = nullptr, 
+    RtErrorCallback errorCallback = nullptr) override;
 
   void joinMatch(
       const std::string& matchId,
@@ -234,7 +236,7 @@ public:
 
   std::future<void> removeChatMessageAsync(const std::string& channelId, const std::string& messageId) override;
 
-  std::future<NMatch> createMatchAsync() override;
+  std::future<NMatch> createMatchAsync(const std::optional<std::string>& name = std::nullopt) override;
 
   std::future<NMatch> joinMatchAsync(const std::string& matchId, const NStringMap& metadata) override;
 

--- a/integrationtests/src/realtime/test_match.cpp
+++ b/integrationtests/src/realtime/test_match.cpp
@@ -108,8 +108,27 @@ void test_rt_matchmaker() {
   test2.stopTest(true);
 }
 
+void test_rt_create_match_with_name() {
+  const bool threadedTick = true;
+  NTest test3(__func__, threadedTick);
+
+  test3.runTest();
+
+  NSessionPtr session = test3.client->authenticateCustomAsync(TestGuid::newGuid(), std::string(), true).get();
+  bool createStatus = false;
+  test3.rtClient->connectAsync(session, createStatus, NTest::RtProtocol).get();
+
+  NMatch match1 = test3.rtClient->createMatchAsync("success").get();
+  NMatch match2 = test3.rtClient->createMatchAsync("success").get();
+
+  test3.stopTest(match1.matchId == match2.matchId);
+
+  NLOG_INFO("stopped create match");
+}
+
 void test_rt_match() {
   test_rt_create_match();
+  test_rt_create_match_with_name();
   test_rt_matchmaker();
 }
 

--- a/interface/include/nakama-cpp/realtime/NRtClientInterface.h
+++ b/interface/include/nakama-cpp/realtime/NRtClientInterface.h
@@ -245,7 +245,8 @@ NAKAMA_NAMESPACE_BEGIN
          * Create a multiplayer match on the server.
          */
         virtual void createMatch(
-            std::function<void(const NMatch&)> successCallback,
+            const std::optional<std::string>& name = std::nullopt,
+            std::function<void(const NMatch&)> successCallback = nullptr,
             RtErrorCallback errorCallback = nullptr
         ) = 0;
 
@@ -523,7 +524,7 @@ NAKAMA_NAMESPACE_BEGIN
         /**
          * Create a multiplayer match on the server.
          */
-        virtual std::future<NMatch> createMatchAsync() = 0;
+        virtual std::future<NMatch> createMatchAsync(const std::optional<std::string>& name = std::nullopt) = 0;
 
         /**
          * Join a multiplayer match by ID.


### PR DESCRIPTION
Closes #77.

Adds the ability to optionally pass a name when creating a match, matching the other Nakama SDKs. Per the documentation, the name is used by the server to generate the match ID, so two clients creating a match with the same name end up in the same match.

## Implementation
- Added an optional `name` parameter to `createMatch` / `createMatchAsync` (and the `NRtClientInterface` declarations), using `std::optional<std::string>` to follow the existing `listMatches` convention.
- Used `std::optional` rather than a defaulted empty string so the no-name behaviour is preserved exactly, `mutable_match_create()` is always called, and `set_name` only runs when a name is actually provided. Existing callers are unaffected.

## Note on the test
The test creates two matches with the same name from a single session and asserts they return the same match ID. If the server behaves differently for a same-session repeat, I'm happy to switch it to a two-session setup like test_rt_matchmaker

## Testing
- Added `test_rt_create_match_with_name` in `test_match.cpp`, registered in `test_rt_match()`. It creates two matches with the same name and asserts they return the same match ID, verifying the name feeds into ID generation.
- Compiles cleanly on Windows (win-x64, MSVC).